### PR TITLE
fix clippy error when exporting svg module

### DIFF
--- a/crates/vsvg/src/lib.rs
+++ b/crates/vsvg/src/lib.rs
@@ -20,12 +20,12 @@ pub mod test_utils;
 mod traits;
 mod unit;
 
+pub use crate::svg::*;
 pub use color::*;
 pub use document::*;
 pub use layer::*;
 pub use page_size::*;
 pub use path::*;
 pub use path_index::IndexBuilder;
-pub use svg::*;
 pub use traits::*;
 pub use unit::*;


### PR DESCRIPTION
Fix for:

```
pub use svg::*;
   |         ^^^ ambiguous name
   |
   = note: ambiguous because of multiple potential import sources
   = note: `svg` could refer to a crate passed with `--extern`
   = help: use `::svg` to refer to this crate unambiguously
note: `svg` could also refer to the module defined here
  --> /Users/jakubantolak/.cargo/registry/src/index.crates.io-6f17d22bba15001f/vsvg-0.1.0-alpha.0/src/lib.rs:18:1
   |
18 | mod svg;
   | ^^^^^^^^
   = help: use `crate::svg` to refer to this module unambiguously
```
