### PR TITLE
Add some `rng_XXX` convenience functions to `whiskers::Context` and make `rng_range` generic over type

### DIFF
--- a/crates/vsvg/src/color.rs
+++ b/crates/vsvg/src/color.rs
@@ -97,3 +97,25 @@ impl fmt::Display for Color {
         )
     }
 }
+
+pub const COLORS: [Color; 19] = [
+    Color::BLACK,
+    Color::DARK_GRAY,
+    Color::GRAY,
+    Color::LIGHT_GRAY,
+    Color::WHITE,
+    Color::BROWN,
+    Color::DARK_RED,
+    Color::RED,
+    Color::LIGHT_RED,
+    Color::YELLOW,
+    Color::LIGHT_YELLOW,
+    Color::KHAKI,
+    Color::DARK_GREEN,
+    Color::GREEN,
+    Color::LIGHT_GREEN,
+    Color::DARK_BLUE,
+    Color::BLUE,
+    Color::LIGHT_BLUE,
+    Color::GOLD,
+];

--- a/crates/vsvg/src/document/mod.rs
+++ b/crates/vsvg/src/document/mod.rs
@@ -78,7 +78,7 @@ pub trait DocumentTrait<L: LayerTrait<P, D>, P: PathTrait<D>, D: PathDataTrait>:
 
         let doc = document_to_svg_doc(self);
         let mut svg = String::new();
-        write!(svg, "{doc}").map(|_| svg)
+        write!(svg, "{doc}").map(|()| svg)
     }
     fn to_svg(&self, writer: impl std::io::Write) -> std::io::Result<()> {
         let doc = document_to_svg_doc(self);

--- a/crates/whiskers/examples/rng.rs
+++ b/crates/whiskers/examples/rng.rs
@@ -21,7 +21,7 @@ impl App for RngSketch {
     fn update(&mut self, sketch: &mut Sketch, ctx: &mut Context) -> anyhow::Result<()> {
         sketch.stroke_width(3.0);
 
-        let should_generate_random_color = ctx.rng_boolean();
+        let should_generate_random_color = ctx.rng_bool();
 
         println!(
             "Was a random color generated? {}",
@@ -54,7 +54,7 @@ impl App for RngSketch {
             Color::GOLD,
         ];
         let chosen_color = if should_generate_random_color {
-            ctx.rng_option(&colors).unwrap()
+            ctx.rng_choice(&colors)
         } else {
             &Color::BLACK
         };

--- a/crates/whiskers/examples/rng.rs
+++ b/crates/whiskers/examples/rng.rs
@@ -21,39 +21,22 @@ impl App for RngSketch {
     fn update(&mut self, sketch: &mut Sketch, ctx: &mut Context) -> anyhow::Result<()> {
         sketch.stroke_width(3.0);
 
-        let should_generate_random_color = ctx.rng_bool();
-
-        println!(
-            "Was a random color generated? {}",
-            if should_generate_random_color {
-                "Yes"
-            } else {
-                "No"
-            }
-        );
-
         let colors = COLORS.to_vec();
-        let chosen_color = if should_generate_random_color {
-            ctx.rng_choice(&colors)
-        } else {
-            &Color::BLACK
-        };
+        let chosen_color = ctx.rng_choice(&colors);
 
-        println!("{}", chosen_color.to_rgb_string());
+        let w = sketch.width();
+        let h = sketch.height();
+        let has_bold_stroke = ctx.rng_bool();
+        let stroke_width = if has_bold_stroke { 10.0 } else { 5.0 };
 
-        sketch.color(*chosen_color);
         sketch
-            .translate(sketch.width() / 2.0, sketch.height() / 2.0)
+            .color(*chosen_color)
+            .stroke_width(stroke_width)
+            .translate(w / 2.0, h / 2.0)
             .rect(0., 0., self.width, self.height);
 
-        let x_range = Range {
-            start: 0.0,
-            end: sketch.width(),
-        };
-        let y_range = Range {
-            start: 0.0,
-            end: sketch.height(),
-        };
+        let x_range = Range { start: 0.0, end: w };
+        let y_range = Range { start: 0.0, end: h };
 
         let some_point = ctx.rng_point(x_range, y_range);
 

--- a/crates/whiskers/examples/rng.rs
+++ b/crates/whiskers/examples/rng.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use std::ops::Range;
 use whiskers::prelude::*;
 
 #[derive(Sketch)]
@@ -18,7 +19,7 @@ impl Default for RngSketch {
 
 impl App for RngSketch {
     fn update(&mut self, sketch: &mut Sketch, ctx: &mut Context) -> anyhow::Result<()> {
-        sketch.color(Color::DARK_RED).stroke_width(3.0);
+        sketch.stroke_width(3.0);
 
         let should_generate_random_color = ctx.rng_boolean();
 
@@ -66,6 +67,21 @@ impl App for RngSketch {
         sketch
             .translate(sketch.width() / 2.0, sketch.height() / 2.0)
             .rect(0., 0., self.width, self.height);
+
+        let x_range = Range {
+            start: 0.0,
+            end: sketch.width(),
+        };
+        let y_range = Range {
+            start: 0.0,
+            end: sketch.height(),
+        };
+
+        let some_point = ctx.rng_point(x_range, y_range);
+
+        sketch.push_matrix_reset();
+        sketch.circle(some_point.x(), some_point.y(), 20.0);
+
         Ok(())
     }
 }

--- a/crates/whiskers/examples/rng.rs
+++ b/crates/whiskers/examples/rng.rs
@@ -32,8 +32,6 @@ impl App for RngSketch {
             }
         );
 
-        let chosen_color;
-
         let colors: Vec<Color> = vec![
             Color::BLACK,
             Color::DARK_GRAY,
@@ -55,7 +53,7 @@ impl App for RngSketch {
             Color::LIGHT_BLUE,
             Color::GOLD,
         ];
-        chosen_color = if should_generate_random_color {
+        let chosen_color = if should_generate_random_color {
             ctx.rng_option(&colors).unwrap()
         } else {
             &Color::BLACK
@@ -63,7 +61,7 @@ impl App for RngSketch {
 
         println!("{}", chosen_color.to_rgb_string());
 
-        sketch.color(Color::from(*chosen_color));
+        sketch.color(*chosen_color);
         sketch
             .translate(sketch.width() / 2.0, sketch.height() / 2.0)
             .rect(0., 0., self.width, self.height);

--- a/crates/whiskers/examples/rng.rs
+++ b/crates/whiskers/examples/rng.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use std::ops::Range;
 use vsvg::COLORS;
 use whiskers::prelude::*;
@@ -66,10 +65,8 @@ impl App for RngSketch {
 }
 
 fn main() -> Result {
-    let mut rng = rand::thread_rng();
-    let num: u32 = rng.gen();
     Runner::new(RngSketch::default())
-        .with_seed(num)
+        .with_random_seed()
         .with_page_size_options(PageSize::A5H)
         .run()
 }

--- a/crates/whiskers/examples/rng.rs
+++ b/crates/whiskers/examples/rng.rs
@@ -1,0 +1,80 @@
+use rand::Rng;
+use whiskers::prelude::*;
+
+#[derive(Sketch)]
+struct RngSketch {
+    width: f64,
+    height: f64,
+}
+
+impl Default for RngSketch {
+    fn default() -> Self {
+        Self {
+            width: 400.0,
+            height: 300.0,
+        }
+    }
+}
+
+impl App for RngSketch {
+    fn update(&mut self, sketch: &mut Sketch, ctx: &mut Context) -> anyhow::Result<()> {
+        sketch.color(Color::DARK_RED).stroke_width(3.0);
+
+        let should_generate_random_color = ctx.rng_boolean();
+
+        println!(
+            "Was a random color generated? {}",
+            if should_generate_random_color {
+                "Yes"
+            } else {
+                "No"
+            }
+        );
+
+        let chosen_color;
+
+        let colors: Vec<Color> = vec![
+            Color::BLACK,
+            Color::DARK_GRAY,
+            Color::GRAY,
+            Color::LIGHT_GRAY,
+            Color::WHITE,
+            Color::BROWN,
+            Color::DARK_RED,
+            Color::RED,
+            Color::LIGHT_RED,
+            Color::YELLOW,
+            Color::LIGHT_YELLOW,
+            Color::KHAKI,
+            Color::DARK_GREEN,
+            Color::GREEN,
+            Color::LIGHT_GREEN,
+            Color::DARK_BLUE,
+            Color::BLUE,
+            Color::LIGHT_BLUE,
+            Color::GOLD,
+        ];
+        chosen_color = if should_generate_random_color {
+            ctx.rng_option(&colors).unwrap()
+        } else {
+            &Color::BLACK
+        };
+
+        println!("{}", chosen_color.to_rgb_string());
+
+        sketch.color(Color::from(*chosen_color));
+        sketch
+            .translate(sketch.width() / 2.0, sketch.height() / 2.0)
+            .rect(0., 0., self.width, self.height);
+        Ok(())
+    }
+}
+
+fn main() -> Result {
+    let mut rng = rand::thread_rng();
+    let num: u32 = rng.gen();
+    Runner::new(RngSketch::default())
+        .with_seed(num)
+        .with_page_size_options(PageSize::A5H)
+        .run()
+}

--- a/crates/whiskers/examples/rng.rs
+++ b/crates/whiskers/examples/rng.rs
@@ -1,5 +1,6 @@
 use rand::Rng;
 use std::ops::Range;
+use vsvg::COLORS;
 use whiskers::prelude::*;
 
 #[derive(Sketch)]
@@ -32,27 +33,7 @@ impl App for RngSketch {
             }
         );
 
-        let colors: Vec<Color> = vec![
-            Color::BLACK,
-            Color::DARK_GRAY,
-            Color::GRAY,
-            Color::LIGHT_GRAY,
-            Color::WHITE,
-            Color::BROWN,
-            Color::DARK_RED,
-            Color::RED,
-            Color::LIGHT_RED,
-            Color::YELLOW,
-            Color::LIGHT_YELLOW,
-            Color::KHAKI,
-            Color::DARK_GREEN,
-            Color::GREEN,
-            Color::LIGHT_GREEN,
-            Color::DARK_BLUE,
-            Color::BLUE,
-            Color::LIGHT_BLUE,
-            Color::GOLD,
-        ];
+        let colors = COLORS.to_vec();
         let chosen_color = if should_generate_random_color {
             ctx.rng_choice(&colors)
         } else {

--- a/crates/whiskers/src/context.rs
+++ b/crates/whiskers/src/context.rs
@@ -40,18 +40,12 @@ impl Context {
 
     /// Helper function to generate a random boolean value
     pub fn rng_boolean(&mut self) -> bool {
-        let num: f64 = self.rng.gen();
-        num > 0.5
+        self.rng.gen_bool(0.5)
     }
 
     /// Helper function to return a random item from a vector
     pub fn rng_option<'a, T>(&mut self, options: &'a Vec<T>) -> Option<&'a T> {
-        let index = self
-            .rng_range(Range {
-                start: 0.0,
-                end: options.len().to_f64(),
-            })
-            .to_usize()?;
+        let index = self.rng_index(options);
 
         options.get(index)
     }
@@ -62,5 +56,14 @@ impl Context {
         let y = self.rng_range(y_range);
 
         Point::new(x, y)
+    }
+
+    fn rng_index<T>(&mut self, options: &Vec<T>) -> usize {
+        self.rng_range(Range {
+            start: 0.0,
+            end: options.len().to_f64(),
+        })
+        .to_usize()
+        .unwrap_or(0)
     }
 }

--- a/crates/whiskers/src/context.rs
+++ b/crates/whiskers/src/context.rs
@@ -1,4 +1,6 @@
+use egui::emath::Numeric;
 use rand::Rng;
+use rand_distr::num_traits::ToPrimitive;
 use std::ops::Range;
 use vsvg::Point;
 
@@ -44,8 +46,13 @@ impl Context {
 
     /// Helper function to return a random item from a vector
     pub fn rng_option<'a, T>(&mut self, options: &'a Vec<T>) -> Option<&'a T> {
-        let num: usize = self.rng.gen();
-        let index = num * options.len();
+        let index = self
+            .rng_range(Range {
+                start: 0.0,
+                end: options.len().to_f64(),
+            })
+            .to_usize()?;
+
         options.get(index)
     }
 

--- a/crates/whiskers/src/context.rs
+++ b/crates/whiskers/src/context.rs
@@ -34,4 +34,17 @@ impl Context {
         }
         self.rng.gen_range(range)
     }
+
+    /// Helper function to generate a random boolean value
+    pub fn rng_boolean(&mut self) -> bool {
+        let num: f64 = self.rng.gen();
+        num > 0.5
+    }
+
+    /// Helper function to return a random item from a vector
+    pub fn rng_option<'a, T>(&mut self, options: &'a Vec<T>) -> Option<&'a T> {
+        let num: f64 = self.rng.gen();
+        let index = (num * options.len() as f64).floor() as usize;
+        options.get(index)
+    }
 }

--- a/crates/whiskers/src/context.rs
+++ b/crates/whiskers/src/context.rs
@@ -49,7 +49,7 @@ impl Context {
         options.get(index)
     }
 
-    /// Helper function to return a random item from a vector
+    /// Helper function to return a random vsvg Point
     pub fn rng_point(&mut self, x_range: Range<f64>, y_range: Range<f64>) -> Point {
         let x = self.rng_range(x_range);
         let y = self.rng_range(y_range);

--- a/crates/whiskers/src/context.rs
+++ b/crates/whiskers/src/context.rs
@@ -1,5 +1,6 @@
 use rand::Rng;
 use std::ops::Range;
+use vsvg::Point;
 
 /// Context passed to [`crate::App::update`].
 pub struct Context {
@@ -46,5 +47,14 @@ impl Context {
         let num: f64 = self.rng.gen();
         let index = (num * options.len() as f64).floor() as usize;
         options.get(index)
+    }
+
+    /// Helper function to return a random item from a vector
+    pub fn rng_point(&mut self, x_range: Range<f64>, y_range: Range<f64>) -> Point {
+        let x = self.rng_range(x_range);
+        let y = self.rng_range(y_range);
+
+        println!("{}, {}", &x, &y);
+        Point::new(x, y)
     }
 }

--- a/crates/whiskers/src/context.rs
+++ b/crates/whiskers/src/context.rs
@@ -44,8 +44,8 @@ impl Context {
 
     /// Helper function to return a random item from a vector
     pub fn rng_option<'a, T>(&mut self, options: &'a Vec<T>) -> Option<&'a T> {
-        let num: f64 = self.rng.gen();
-        let index = (num * options.len() as f64).floor() as usize;
+        let num: usize = self.rng.gen();
+        let index = num * options.len();
         options.get(index)
     }
 

--- a/crates/whiskers/src/context.rs
+++ b/crates/whiskers/src/context.rs
@@ -1,6 +1,5 @@
-use egui::emath::Numeric;
+use rand::distributions::uniform::SampleUniform;
 use rand::Rng;
-use rand_distr::num_traits::ToPrimitive;
 use std::ops::Range;
 use vsvg::Point;
 
@@ -31,7 +30,7 @@ impl Context {
 
     /// Helper function to generate a random number in a given range. This function accepts an empty
     /// range, in which case it will always return the start value.
-    pub fn rng_range(&mut self, range: Range<f64>) -> f64 {
+    pub fn rng_range<T: SampleUniform + PartialOrd>(&mut self, range: Range<T>) -> T {
         if range.is_empty() {
             return range.start;
         }
@@ -39,15 +38,22 @@ impl Context {
     }
 
     /// Helper function to generate a random boolean value
-    pub fn rng_boolean(&mut self) -> bool {
+    pub fn rng_bool(&mut self) -> bool {
         self.rng.gen_bool(0.5)
     }
 
-    /// Helper function to return a random item from a vector
-    pub fn rng_option<'a, T>(&mut self, options: &'a Vec<T>) -> Option<&'a T> {
-        let index = self.rng_index(options);
+    /// Helper function to return a random item from a slice
+    ///
+    /// # Panics
+    ///
+    /// Panics if the slice is empty.
+    pub fn rng_choice<'a, T>(&mut self, choices: &'a impl AsRef<[T]>) -> &'a T {
+        let index = self.rng_range(Range {
+            start: 0usize,
+            end: choices.as_ref().len(),
+        });
 
-        options.get(index)
+        choices.as_ref().get(index).unwrap()
     }
 
     /// Helper function to return a random vsvg Point
@@ -56,14 +62,5 @@ impl Context {
         let y = self.rng_range(y_range);
 
         Point::new(x, y)
-    }
-
-    fn rng_index<T>(&mut self, options: &Vec<T>) -> usize {
-        self.rng_range(Range {
-            start: 0.0,
-            end: options.len().to_f64(),
-        })
-        .to_usize()
-        .unwrap_or(0)
     }
 }

--- a/crates/whiskers/src/context.rs
+++ b/crates/whiskers/src/context.rs
@@ -54,7 +54,6 @@ impl Context {
         let x = self.rng_range(x_range);
         let y = self.rng_range(y_range);
 
-        println!("{}, {}", &x, &y);
         Point::new(x, y)
     }
 }

--- a/crates/whiskers/src/runner/save_ui_native.rs
+++ b/crates/whiskers/src/runner/save_ui_native.rs
@@ -121,7 +121,7 @@ impl SaveUI {
                         {
                             if let Some(sketch) = sketch {
                                 if let Some(path) = self.get_output_path() {
-                                    self.last_error = Some(sketch.save(&path).map(|_| {
+                                    self.last_error = Some(sketch.save(&path).map(|()| {
                                         path.file_name().map_or("<unknown>".to_string(), |s| {
                                             s.to_string_lossy().to_string()
                                         })


### PR DESCRIPTION
A feature idea for extending a bit current random value generation capabilities of whiskers' sketch context. 

This would make easier for the users to pick random items from lists (vectors) and generate random boolean values or points.

It's especially useful when working with projects published on platforms like [fxhash](https://www.fxhash.xyz/). I'd also add some other utilities like `rng_weighted_option` and other in separate pull request(s).

Inspiration: Liam Egan's [FXHash Helpers](https://github.com/liamegan/fxhash-helpers).