### PR TITLE
Added support for Catmull-Rom splines

### DIFF
--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    name: "lint, tests, clippy"
+    name: "lint, tests, clippy, docs"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -32,3 +32,4 @@ jobs:
       - run: just fmt
       - run: just clippy
       - run: just test
+      - run: just docs

--- a/crates/vsvg/src/catmull_rom.rs
+++ b/crates/vsvg/src/catmull_rom.rs
@@ -52,6 +52,7 @@ impl CatmullRom {
     }
 
     /// Get the control points.
+    #[must_use]
     pub fn points(&self) -> &[Point] {
         &self.points
     }

--- a/crates/vsvg/src/catmull_rom.rs
+++ b/crates/vsvg/src/catmull_rom.rs
@@ -1,0 +1,112 @@
+use crate::{IntoBezPathTolerance, Point};
+use kurbo::{BezPath, CubicBez};
+
+/// A Catmull-Rom spline.
+///
+/// This is a curve that passes through all the points in the list, but is smooth. It is converted
+/// to a series of cubic Bézier curves.
+///
+/// A minimum of 3 control points are needed to create a curve. If less than 3 points are provided,
+/// an empty path is returned.
+///
+/// Strictly speaking, a Catmull-Rom spline starts at the second point and ends at the second to
+/// last. This implementation duplicates the first and last points instead, so that all points are
+/// traversed by the curve.
+///
+/// The Catmull-Rom spline is parameterized by a `tension` parameter. A tension of 1.0 is the
+/// default. Higher values will make the curve more "tight" (closer to a polyline), while lower
+/// values will make it more "loose". Values bellow ~0.2 yield very loose curves that can extend far
+/// away from the control points. Negative values makes the curve pass backwards through control
+/// points.
+#[derive(Debug, Clone)]
+pub struct CatmullRom {
+    points: Vec<Point>,
+    tension: f64,
+}
+
+impl Default for CatmullRom {
+    fn default() -> Self {
+        Self {
+            tension: 1.0,
+            points: Vec::new(),
+        }
+    }
+}
+
+impl CatmullRom {
+    /// Create a new Catmull-Rom spline from a list of points.
+    ///
+    /// The `tension` parameter is set to 1.0.
+    pub fn from_points(points: impl IntoIterator<Item = impl Into<Point>>) -> Self {
+        Self {
+            tension: 1.0,
+            points: points.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Set the tension parameter.
+    #[must_use]
+    pub fn tension(mut self, tension: f64) -> Self {
+        self.tension = tension;
+        self
+    }
+
+    /// Get the control points.
+    pub fn points(&self) -> &[Point] {
+        &self.points
+    }
+
+    /// Add a control point.
+    pub fn push_point(&mut self, point: impl Into<Point>) {
+        self.points.push(point.into());
+    }
+}
+
+fn cubic_bez_from_catmull_rom_points(
+    p0: Point,
+    p1: Point,
+    p2: Point,
+    p3: Point,
+    tension: f64,
+) -> CubicBez {
+    CubicBez::new(
+        p1,
+        p1 + (p2 - p0) / 6.0 / tension,
+        p2 - (p3 - p1) / 6.0 / tension,
+        p2,
+    )
+}
+
+impl IntoBezPathTolerance for CatmullRom {
+    fn into_bezpath_with_tolerance(self, _tolerance: f64) -> BezPath {
+        let tension = self.tension;
+
+        if self.points.len() < 3 {
+            return BezPath::new();
+        }
+
+        BezPath::from_path_segments(
+            [cubic_bez_from_catmull_rom_points(
+                self.points[0],
+                self.points[0],
+                self.points[1],
+                self.points[2],
+                tension,
+            )]
+            .into_iter()
+            .chain(
+                self.points
+                    .windows(4)
+                    .map(|w| cubic_bez_from_catmull_rom_points(w[0], w[1], w[2], w[3], tension)),
+            )
+            .chain([cubic_bez_from_catmull_rom_points(
+                self.points[self.points.len() - 3],
+                self.points[self.points.len() - 2],
+                self.points[self.points.len() - 1],
+                self.points[self.points.len() - 1],
+                tension,
+            )])
+            .map(kurbo::PathSeg::Cubic),
+        )
+    }
+}

--- a/crates/vsvg/src/lib.rs
+++ b/crates/vsvg/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::missing_errors_doc)]
 
+mod catmull_rom;
 mod color;
 mod crop;
 mod document;
@@ -23,6 +24,7 @@ mod unit;
 pub use crate::svg::*;
 pub use color::*;
 
+pub use catmull_rom::*;
 pub use crop::*;
 pub use document::*;
 pub use layer::*;

--- a/crates/vsvg/src/path/point.rs
+++ b/crates/vsvg/src/path/point.rs
@@ -1,5 +1,3 @@
-use std::ops::{Div, Mul};
-
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Point {
     data: [f64; 2],
@@ -185,7 +183,7 @@ impl std::ops::Sub for Point {
     }
 }
 
-impl Mul<f64> for Point {
+impl std::ops::Mul<f64> for Point {
     type Output = Self;
 
     #[inline]
@@ -194,7 +192,7 @@ impl Mul<f64> for Point {
     }
 }
 
-impl Mul<Point> for f64 {
+impl std::ops::Mul<Point> for f64 {
     type Output = Point;
 
     #[inline]
@@ -203,7 +201,7 @@ impl Mul<Point> for f64 {
     }
 }
 
-impl Div<f64> for Point {
+impl std::ops::Div<f64> for Point {
     type Output = Self;
 
     #[inline]
@@ -212,7 +210,7 @@ impl Div<f64> for Point {
     }
 }
 
-impl Mul<Point> for kurbo::Affine {
+impl std::ops::Mul<Point> for kurbo::Affine {
     type Output = Point;
 
     #[inline]

--- a/crates/vsvg/src/path/point.rs
+++ b/crates/vsvg/src/path/point.rs
@@ -1,4 +1,4 @@
-use std::ops::Mul;
+use std::ops::{Div, Mul};
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Point {
@@ -164,6 +164,51 @@ impl From<&Point> for egui::Pos2 {
 impl From<glam::Vec2> for Point {
     fn from(p: glam::Vec2) -> Self {
         Self::new(f64::from(p.x), f64::from(p.y))
+    }
+}
+
+impl std::ops::Add for Point {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, other: Self) -> Self {
+        Self::new(self.x() + other.x(), self.y() + other.y())
+    }
+}
+
+impl std::ops::Sub for Point {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, other: Self) -> Self {
+        Self::new(self.x() - other.x(), self.y() - other.y())
+    }
+}
+
+impl Mul<f64> for Point {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, other: f64) -> Self {
+        Self::new(self.x() * other, self.y() * other)
+    }
+}
+
+impl Mul<Point> for f64 {
+    type Output = Point;
+
+    #[inline]
+    fn mul(self, other: Point) -> Point {
+        other * self
+    }
+}
+
+impl Div<f64> for Point {
+    type Output = Self;
+
+    #[inline]
+    fn div(self, other: f64) -> Self {
+        Self::new(self.x() / other, self.y() / other)
     }
 }
 

--- a/crates/vsvg/src/traits/draw.rs
+++ b/crates/vsvg/src/traits/draw.rs
@@ -121,6 +121,18 @@ pub trait Draw {
         ))
     }
 
+    /// Draw a Catmull-Rom spline from a sequence of points and a tension parameter.
+    ///
+    /// See [`CatmullRom`] for more information.
+    fn catmull_rom(
+        &mut self,
+        points: impl IntoIterator<Item = impl Into<Point>>,
+        tension: f64,
+    ) -> &mut Self {
+        self.add_path(crate::CatmullRom::from_points(points).tension(tension));
+        self
+    }
+
     /// Draw from an SVG path representation.
     fn svg_path(&mut self, path: &str) -> Result<&mut Self, kurbo::SvgParseError> {
         self.add_path(kurbo::BezPath::from_svg(path)?);

--- a/crates/vsvg/src/traits/draw.rs
+++ b/crates/vsvg/src/traits/draw.rs
@@ -123,7 +123,7 @@ pub trait Draw {
 
     /// Draw a Catmull-Rom spline from a sequence of points and a tension parameter.
     ///
-    /// See [`CatmullRom`] for more information.
+    /// See [`crate::CatmullRom`] for more information.
     fn catmull_rom(
         &mut self,
         points: impl IntoIterator<Item = impl Into<Point>>,

--- a/crates/whiskers/examples/catmull_rom.rs
+++ b/crates/whiskers/examples/catmull_rom.rs
@@ -1,0 +1,47 @@
+use whiskers::prelude::*;
+
+#[derive(Sketch)]
+struct CatmullRomSketch {
+    #[param(slider, min = 3, max = 60)]
+    num_points: usize,
+
+    #[param(slider, min = 0.01, max = 10.0)]
+    tension: f64,
+
+    negative_tension: bool,
+}
+
+impl Default for CatmullRomSketch {
+    fn default() -> Self {
+        Self {
+            num_points: 10,
+            tension: 1.0,
+            negative_tension: false,
+        }
+    }
+}
+
+impl App for CatmullRomSketch {
+    fn update(&mut self, sketch: &mut Sketch, ctx: &mut Context) -> anyhow::Result<()> {
+        sketch.color(Color::DARK_RED);
+
+        let points = (0..self.num_points)
+            .map(|_| ctx.rng_point(50.0..sketch.width() - 50.0, 50.0..sketch.height() - 50.0))
+            .collect::<Vec<_>>();
+
+        for pts in &points {
+            sketch.circle(pts.x(), pts.y(), 1.);
+        }
+
+        sketch.catmull_rom(points, self.tension);
+
+        Ok(())
+    }
+}
+
+fn main() -> Result {
+    Runner::new(CatmullRomSketch::default())
+        .with_page_size_options(PageSize::A5H)
+        .with_layout_option(LayoutOptions::Center)
+        .run()
+}

--- a/crates/whiskers/examples/sketch_only.rs
+++ b/crates/whiskers/examples/sketch_only.rs
@@ -1,4 +1,5 @@
-//! This example demonstrates how to directly use [`Sketch`] without using the [`run`]/[`App`] API.
+//! This example demonstrates how to directly use [`whiskers::Sketch`] without using the [`Runner`]
+//! API.
 use whiskers::prelude::*;
 
 fn main() -> Result {

--- a/justfile
+++ b/justfile
@@ -7,6 +7,9 @@ clippy $RUSTFLAGS="-Dwarnings":
 clippy-wasm $RUSTFLAGS="-Dwarnings":
     cargo clippy --workspace --all-features --exclude msvg --exclude vsvg-cli --bins --target wasm32-unknown-unknown
 
+docs $RUSTDOCFLAGS="-Dwarnings":
+    cargo doc --all-features --no-deps --bins --examples -p whiskers -p vsvg
+
 fmt:
     cargo fmt --all -- --check
 

--- a/justfile
+++ b/justfile
@@ -24,6 +24,6 @@ web-serve:
     basic-http-server crates/whiskers-web-demo/web
 
 test:
-    cargo test
+    cargo test --workspace --all-features --bins --examples
 
 lint: clippy clippy-wasm fmt test


### PR DESCRIPTION
- Added `vsvg::CatmullRom`, which can be converted to `BezPath`
- Added `Sketch::catmull_rom()` function
- Added `catmull_rom.rs` example
- Added support for addition/subtraction for `vsvg::Point` as well as multiplication/division by a scalar