### PR TITLE
Rename `whiskers::Runner::with_layout_options` for consistency

### DIFF
--- a/crates/whiskers-web-demo/src/lib.rs
+++ b/crates/whiskers-web-demo/src/lib.rs
@@ -65,7 +65,7 @@ impl App for WhiskersDemoSketch {
 }
 
 wasm_sketch!(Runner::new(WhiskersDemoSketch::default())
-    .with_layout_option(LayoutOptions::centered())
+    .with_layout_options(LayoutOptions::centered())
     .with_info_options(
         InfoOptions::default()
             .description(

--- a/crates/whiskers/examples/catmull_rom.rs
+++ b/crates/whiskers/examples/catmull_rom.rs
@@ -42,6 +42,6 @@ impl App for CatmullRomSketch {
 fn main() -> Result {
     Runner::new(CatmullRomSketch::default())
         .with_page_size_options(PageSize::A5H)
-        .with_layout_option(LayoutOptions::Center)
+        .with_layout_options(LayoutOptions::Center)
         .run()
 }

--- a/crates/whiskers/src/runner/mod.rs
+++ b/crates/whiskers/src/runner/mod.rs
@@ -123,7 +123,7 @@ impl Runner<'_> {
 
     /// Sets the default layout options.
     #[must_use]
-    pub fn with_layout_option(self, options: impl Into<LayoutOptions>) -> Self {
+    pub fn with_layout_options(self, options: impl Into<LayoutOptions>) -> Self {
         Self {
             layout_options: options.into(),
             ..self


### PR DESCRIPTION
It was previously in singular form.