### PR TITLE
Add logarithmic slider support to numerical sketch parameter

### DIFF
--- a/crates/whiskers/examples/catmull_rom.rs
+++ b/crates/whiskers/examples/catmull_rom.rs
@@ -5,7 +5,7 @@ struct CatmullRomSketch {
     #[param(slider, min = 3, max = 60)]
     num_points: usize,
 
-    #[param(slider, min = 0.01, max = 10.0)]
+    #[param(logarithmic, min = 0.01, max = 100.0)]
     tension: f64,
 
     negative_tension: bool,
@@ -33,7 +33,10 @@ impl App for CatmullRomSketch {
             sketch.circle(pts.x(), pts.y(), 1.);
         }
 
-        sketch.catmull_rom(points, self.tension);
+        sketch.catmull_rom(
+            points,
+            self.tension * if self.negative_tension { -1. } else { 1. },
+        );
 
         Ok(())
     }

--- a/crates/whiskers/src/widgets/numeric_widget.rs
+++ b/crates/whiskers/src/widgets/numeric_widget.rs
@@ -9,6 +9,7 @@ pub struct NumericWidget<T: Numeric> {
     max: Option<T>,
     step: Option<T>,
     slider: bool,
+    logarithmic: bool,
 }
 
 impl<T: Numeric> NumericWidget<T> {
@@ -39,6 +40,16 @@ impl<T: Numeric> NumericWidget<T> {
         self.slider = slider;
         self
     }
+
+    /// Sets the widget to logarithmic mode. Implies [`slider(true)`].
+    #[must_use]
+    pub fn logarithmic(mut self, log: bool) -> Self {
+        self.logarithmic = log;
+        if log {
+            self.slider = true;
+        }
+        self
+    }
 }
 
 impl<T: Numeric> super::Widget<T> for NumericWidget<T> {
@@ -49,6 +60,9 @@ impl<T: Numeric> super::Widget<T> for NumericWidget<T> {
             let mut slider = egui::Slider::new(value, range);
             if let Some(step) = self.step {
                 slider = slider.step_by(step.to_f64());
+            }
+            if self.logarithmic {
+                slider = slider.logarithmic(true);
             }
             ui.add(slider)
         } else {


### PR DESCRIPTION
This is done by using `#[param(logarithmic, min = ..., max = ...)]`, which implies `slider`.