### PR TITLE
Fix spurious colon in `bool` UI widget label

### DIFF
--- a/crates/whiskers/src/widgets/bool.rs
+++ b/crates/whiskers/src/widgets/bool.rs
@@ -7,7 +7,7 @@ impl super::Widget<bool> for BoolWidget {
         // empty first column
         ui.horizontal(|_| {});
 
-        ui.checkbox(value, label)
+        ui.checkbox(value, label.trim_end_matches(':'))
     }
 }
 


### PR DESCRIPTION
The `Sketch` proc macro adds a `:` to the label provided to UI widgets, but `BoolWidget` uses that label as checkbox label, so it shouldn't have one. It now strips it if found.