### PR TITLE
Add in-process profiling with `puffin` and parallelize some layer-level operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1898,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2134,6 +2144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,6 +2297,12 @@ dependencies = [
  "thiserror",
  "unicode-xid",
 ]
+
+[[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
 name = "ndk"
@@ -2742,6 +2764,39 @@ name = "profiling"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
+
+[[package]]
+name = "puffin"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76425abd4e1a0ad4bd6995dd974b52f414fca9974171df8e3708b3e660d05a21"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "byteorder",
+ "cfg-if",
+ "instant",
+ "lz4_flex",
+ "once_cell",
+ "parking_lot",
+ "serde",
+]
+
+[[package]]
+name = "puffin_egui"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f0ef87ac588ec9a979ea4952042134ff047407436aa6859ba9e061f55ca55d"
+dependencies = [
+ "egui",
+ "indexmap 1.9.3",
+ "instant",
+ "natord",
+ "once_cell",
+ "puffin",
+ "time",
+ "vec1",
+]
 
 [[package]]
 name = "quick-xml"
@@ -3795,6 +3850,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
 
 [[package]]
+name = "vec1"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bda7c41ca331fe9a1c278a9e7ee055f4be7f5eb1c2b72f079b4ff8b5fce9d5c"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,9 +3896,11 @@ dependencies = [
  "lazy_static",
  "log",
  "lyon_geom",
+ "puffin",
  "quick-xml",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -3879,6 +3942,8 @@ dependencies = [
  "kurbo",
  "log",
  "pollster",
+ "puffin",
+ "puffin_egui",
  "rand 0.8.5",
  "raw-window-handle",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,12 @@ getrandom = { version = "0", features = ["js"] } # wasm support
 itertools = "0.11.0"
 kurbo = "0.9.1"
 log = "0.4.20"
+puffin = "0.16.0"  # sync with egui
+puffin_egui = "0.22.0"  # sync with egui
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_distr = "0.4.3"
+rayon = "1.8.0"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1.0.107"
 thiserror = "1.0.49"

--- a/crates/vsvg-cli/Cargo.toml
+++ b/crates/vsvg-cli/Cargo.toml
@@ -36,5 +36,6 @@ dhat = { version = "0.3.2", optional = true } # for heap profiling
 #debug = 1
 
 [features]
+puffin = ["vsvg/puffin", "vsvg-viewer/puffin"]
 dhat-heap = ["dhat"]    # if you are doing heap profiling
 dhat-ad-hoc = []  # if you are doing ad hoc profiling

--- a/crates/vsvg-viewer/Cargo.toml
+++ b/crates/vsvg-viewer/Cargo.toml
@@ -19,6 +19,8 @@ eframe.workspace = true
 egui.workspace = true
 kurbo.workspace = true
 log.workspace = true
+puffin = { workspace = true, optional = true }
+puffin_egui = { workspace = true, optional = true }
 serde.workspace = true
 vsvg.workspace = true
 wgpu.workspace = true
@@ -39,3 +41,7 @@ winit = "0.28.3"
 js-sys = "0.3.64"
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.37"
+
+
+[features]
+puffin = ["dep:puffin", "dep:puffin_egui", "vsvg/puffin"]

--- a/crates/vsvg-viewer/src/document_widget.rs
+++ b/crates/vsvg-viewer/src/document_widget.rs
@@ -69,11 +69,14 @@ impl DocumentWidget {
     }
 
     pub fn set_document_data(&mut self, doc_data: DocumentData) {
+        vsvg::trace_function!();
         self.new_document_data = Some(Arc::new(doc_data));
     }
 
     #[allow(clippy::missing_panics_doc)]
     pub fn ui(&mut self, ui: &mut Ui) {
+        vsvg::trace_function!();
+
         let (rect, response) = ui.allocate_exact_size(ui.available_size(), Sense::click_and_drag());
 
         // fit to view on request
@@ -129,6 +132,7 @@ impl DocumentWidget {
 
         let cb = egui_wgpu::CallbackFn::new()
             .prepare(move |device, queue, _encoder, paint_callback_resources| {
+                vsvg::trace_scope!("wgpu prepare callback");
                 let engine: &mut Engine = paint_callback_resources.get_mut().unwrap();
 
                 if let Some(new_doc_data) = new_doc_data.clone() {
@@ -138,6 +142,7 @@ impl DocumentWidget {
                 Vec::new()
             })
             .paint(move |_info, render_pass, paint_callback_resources| {
+                vsvg::trace_scope!("wgpu paint callback");
                 let engine: &Engine = paint_callback_resources.get().unwrap();
                 engine.paint(render_pass);
             });

--- a/crates/vsvg-viewer/src/engine.rs
+++ b/crates/vsvg-viewer/src/engine.rs
@@ -112,8 +112,10 @@ pub struct DocumentData {
 impl DocumentData {
     #[must_use]
     pub fn new(document: &Document) -> Self {
+        vsvg::trace_function!();
+
         Self {
-            flattened_document: document.flatten(0.01), //TODO: magic number
+            flattened_document: document.flatten(0.1), //TODO: magic number
             control_points: document.control_points(),
             display_vertices: document
                 .layers
@@ -354,6 +356,8 @@ impl Engine {
         scale: f32,
         origin: cgmath::Point2<f32>,
     ) {
+        vsvg::trace_function!();
+
         // Update our uniform buffer with the angle from the UI
         let mut camera_uniform = CameraUniform::default();
         camera_uniform.update(
@@ -371,6 +375,8 @@ impl Engine {
     }
 
     pub(super) fn paint<'rp>(&'rp self, render_pass: &mut wgpu::RenderPass<'rp>) {
+        vsvg::trace_function!();
+
         if let Some(page_size_painter_data) = &self.page_size_painter_data {
             self.page_size_painter.draw(
                 render_pass,

--- a/crates/vsvg-viewer/src/lib.rs
+++ b/crates/vsvg-viewer/src/lib.rs
@@ -92,6 +92,8 @@ pub trait ViewerApp {
 /// For native use only.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn show_with_viewer_app(viewer_app: impl ViewerApp + 'static) -> anyhow::Result<()> {
+    vsvg::trace_function!();
+
     let viewer_app = Box::new(viewer_app);
     let document_data = std::sync::Arc::new(DocumentData::default());
 

--- a/crates/vsvg/Cargo.toml
+++ b/crates/vsvg/Cargo.toml
@@ -21,7 +21,9 @@ kurbo.workspace = true
 lazy_static = "1.4.0"
 log.workspace = true
 lyon_geom = "1.0.4"
+puffin = { workspace = true, optional = true }
 quick-xml = "0.30.0"
+rayon.workspace = true
 regex = "1.7.1"
 serde.workspace = true
 serde_json.workspace = true
@@ -46,6 +48,7 @@ criterion = "0.5.1"
 
 [features]
 default = ["geo"]
+puffin = ["dep:puffin"]
 
 [[bench]]
 name = "bench_path_index"

--- a/crates/vsvg/src/document/document.rs
+++ b/crates/vsvg/src/document/document.rs
@@ -50,6 +50,8 @@ impl Document {
 
     #[must_use]
     pub fn flatten(&self, tolerance: f64) -> FlattenedDocument {
+        crate::trace_function!();
+
         FlattenedDocument::new(
             self.layers
                 .iter()
@@ -61,6 +63,8 @@ impl Document {
 
     #[must_use]
     pub fn control_points(&self) -> FlattenedDocument {
+        crate::trace_function!();
+
         FlattenedDocument::new(
             self.layers
                 .iter()

--- a/crates/vsvg/src/lib.rs
+++ b/crates/vsvg/src/lib.rs
@@ -36,6 +36,30 @@ pub use stats::*;
 pub use traits::*;
 pub use unit::*;
 
+// re-export for the `trace` macro
+#[cfg(feature = "puffin")]
+pub use puffin;
+
 // re-export
 #[cfg(feature = "geo")]
 pub use ::geo;
+
+#[macro_export]
+macro_rules! trace_function {
+    () => {
+        #[cfg(feature = "puffin")]
+        $crate::puffin::profile_function!();
+    };
+}
+
+#[macro_export]
+macro_rules! trace_scope {
+    ($id:expr) => {
+        #[cfg(feature = "puffin")]
+        $crate::puffin::profile_scope!($id);
+    };
+    ($id:expr, $data:expr) => {
+        #[cfg(feature = "puffin")]
+        $crate::puffin::profile_scope!($id, $data);
+    };
+}

--- a/crates/vsvg/src/path/path.rs
+++ b/crates/vsvg/src/path/path.rs
@@ -154,6 +154,8 @@ impl Path {
 
     #[must_use]
     pub fn flatten(&self, tolerance: f64) -> Vec<FlattenedPath> {
+        crate::trace_function!();
+
         let mut lines: Vec<FlattenedPath> = vec![];
         let current_line: RefCell<Polyline> = RefCell::new(Polyline::default());
 
@@ -189,6 +191,8 @@ impl Path {
 
     #[must_use]
     pub fn control_points(&self) -> Vec<FlattenedPath> {
+        crate::trace_function!();
+
         self.data
             .segments()
             .filter_map(|segment| match segment {
@@ -208,6 +212,8 @@ impl Path {
     }
 
     pub fn crop(&mut self, x_min: f64, y_min: f64, x_max: f64, y_max: f64) -> &Self {
+        crate::trace_function!();
+
         let new_bezpath = BezPath::from_path_segments(self.data.segments().flat_map(|segment| {
             match segment {
                 kurbo::PathSeg::Line(line) => line

--- a/crates/whiskers/Cargo.toml
+++ b/crates/whiskers/Cargo.toml
@@ -63,3 +63,4 @@ voronoice = "0.2.0"
 [features]
 default = ["viewer"]
 viewer = ["dep:vsvg-viewer"]
+puffin = ["vsvg/puffin", "vsvg-viewer/puffin"]

--- a/crates/whiskers/examples/asteroid.rs
+++ b/crates/whiskers/examples/asteroid.rs
@@ -9,7 +9,6 @@ use rand::Rng;
 use rand_distr::{Distribution, Normal};
 
 use std::f64::consts::PI;
-use vsvg::Color;
 use whiskers::prelude::*;
 
 #[derive(Sketch)]
@@ -48,6 +47,8 @@ impl Default for AsteroidSketch {
 
 impl App for AsteroidSketch {
     fn update(&mut self, sketch: &mut Sketch, ctx: &mut Context) -> anyhow::Result<()> {
+        vsvg::trace_function!();
+
         sketch
             .translate(sketch.width() / 2., sketch.height() / 2.)
             .scale(4.0 * Unit::Cm)
@@ -125,6 +126,8 @@ fn generate_polygon(
     num_vertices: usize,
     rng: &mut impl Rng,
 ) -> geo::Polygon<f64> {
+    vsvg::trace_function!();
+
     irregularity *= 2.0 * PI / num_vertices as f64;
     spikiness *= avg_radius;
     let normal = Normal::new(avg_radius, spikiness).unwrap();
@@ -144,6 +147,8 @@ fn generate_polygon(
 }
 
 fn random_angle_steps(steps: usize, irregularity: f64, rng: &mut impl Rng) -> Vec<f64> {
+    vsvg::trace_function!();
+
     let mut angles = vec![0.0; steps];
     let lower = (2.0 * PI / (steps as f64)) - irregularity;
     let upper = (2.0 * PI / (steps as f64)) + irregularity;
@@ -165,6 +170,8 @@ fn generate_points_in_poly(
     cnt: usize,
     rng: &mut impl Rng,
 ) -> geo::MultiPoint<f64> {
+    vsvg::trace_function!();
+
     let Some(bbox) = poly.bounding_rect() else {
         return geo::MultiPoint::<f64>::new(vec![]);
     };
@@ -188,6 +195,8 @@ fn voronoi(
     bbox: Option<geo::Rect<f64>>,
     points: &geo::MultiPoint<f64>,
 ) -> (geo::MultiPolygon<f64>, geo::MultiLineString<f64>) {
+    vsvg::trace_function!();
+
     let bbox = bbox.map(|r| {
         voronoice::BoundingBox::new(
             voronoice::Point {

--- a/crates/whiskers/examples/catmull_rom.rs
+++ b/crates/whiskers/examples/catmull_rom.rs
@@ -2,7 +2,7 @@ use whiskers::prelude::*;
 
 #[derive(Sketch)]
 struct CatmullRomSketch {
-    #[param(slider, min = 3, max = 60)]
+    #[param(slider, min = 3, max = 1500)]
     num_points: usize,
 
     #[param(logarithmic, min = 0.01, max = 100.0)]

--- a/crates/whiskers/src/runner/mod.rs
+++ b/crates/whiskers/src/runner/mod.rs
@@ -144,6 +144,8 @@ impl Runner<'_> {
 impl Runner<'static> {
     /// Execute the sketch app.
     pub fn run(self) -> anyhow::Result<()> {
+        vsvg::trace_function!();
+
         vsvg_viewer::show_with_viewer_app(self)
     }
 }
@@ -220,6 +222,8 @@ impl vsvg_viewer::ViewerApp for Runner<'_> {
         ctx: &egui::Context,
         document_widget: &mut DocumentWidget,
     ) -> anyhow::Result<()> {
+        vsvg::trace_function!();
+
         if self.animation_options.update_time() {
             self.dirty();
         }
@@ -280,8 +284,14 @@ impl vsvg_viewer::ViewerApp for Runner<'_> {
 
             let mut sketch = Sketch::new();
             sketch.page_size(self.page_size_options.page_size);
-            self.app.update(&mut sketch, &mut context)?;
-            self.layout_options.apply(&mut sketch);
+            {
+                vsvg::trace_scope!("sketch: update");
+                self.app.update(&mut sketch, &mut context)?;
+            }
+            {
+                vsvg::trace_scope!("sketch: layout");
+                self.layout_options.apply(&mut sketch);
+            }
             document_widget.set_document_data(vsvg_viewer::DocumentData::new(sketch.document()));
             self.last_sketch = Some(sketch);
 


### PR DESCRIPTION
In particular, path flattening got ~3x faster through parallelization using rayon.

![image](https://github.com/abey79/vsvg/assets/49431240/a310b3c5-e379-4725-ac23-5b7072dde315)
