### PR TITLE
Implement `step` UI parameter for numeric value in normal mode

### DIFF
--- a/crates/whiskers/examples/noise.rs
+++ b/crates/whiskers/examples/noise.rs
@@ -8,7 +8,11 @@ use whiskers::prelude::*;
 struct NoiseSketch {
     #[param(slider, min = 0.0, max = 500.0)]
     margin: f64,
+
+    #[param(step = 10)]
     line_count: usize,
+
+    #[param(step = 10)]
     points_per_line: usize,
 
     gain: f64,

--- a/crates/whiskers/src/widgets/numeric.rs
+++ b/crates/whiskers/src/widgets/numeric.rs
@@ -28,6 +28,9 @@ impl<T: Numeric> NumericWidget<T> {
     }
 
     /// Sets the step value for the widget.
+    ///
+    /// This parameter is passed to [`egui::DragValue::speed`] in normal mode, and
+    /// [`egui::Slider::step_by`] in slider mode.
     #[must_use]
     pub fn step(mut self, step: T) -> Self {
         self.step = Some(step);
@@ -66,7 +69,11 @@ impl<T: Numeric> super::Widget<T> for NumericWidget<T> {
             }
             ui.add(slider)
         } else {
-            ui.add(egui::DragValue::new(value).clamp_range(range))
+            let mut drag_value = egui::DragValue::new(value).clamp_range(range);
+            if let Some(step) = self.step {
+                drag_value = drag_value.speed(step.to_f64());
+            }
+            ui.add(drag_value)
         }
     }
 }


### PR DESCRIPTION
So far, `step` would operate only in `slider` mode for numeric types:

```rust
#[derive(Sketch)]
struct MySketch {
    // OK: `step` works
    #[param(slider, step = 10)]
    my_param: u64,

    // NOK: `step` compiles, but has no effect
    #[param(step = 10)]
    my_other_param: u64,
}
```

With this PR, `step` works also works on normal mode.