### PR TITLE
Add "merge layers" operation to `vsvg` and `vsvg-cli`

### DIFF
--- a/crates/vsvg-cli/src/commands.rs
+++ b/crates/vsvg-cli/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::cli::{CommandDesc, CommandValue};
 use clap::{arg, value_parser, Arg, Id};
 use std::collections::HashMap;
-use vsvg::{DocumentTrait, Draw, IndexBuilder, Transforms};
+use vsvg::{DocumentTrait, Draw, Transforms};
 
 // https://stackoverflow.com/a/38361018/229511
 macro_rules! count_items {
@@ -137,14 +137,9 @@ pub(crate) fn command_list() -> HashMap<Id, CommandDesc<'static>> {
             |state, b| state.document.for_each(|layer| layer.sort(*b))
         ),
         command_decl!(
-            arg!(--linesortnoflip <THRES> "Reorder paths to minimize pen-up distance"),
-            LayerID, // hack
-            |state, b| state.document.for_each(|layer| layer.sort_with_builder(IndexBuilder::new().flip(false)))
-        ),
-        command_decl!(
-            arg!(--linesortflip <THRES> "Reorder paths to minimize pen-up distance"),
-            LayerID, // hack
-            |state, b| state.document.for_each(|layer| layer.sort_with_builder(IndexBuilder::new().flip(true)))
+            arg!(--layermerge "Merge all layers into layer 1"),
+            bool,
+            |state, b| state.document.merge_layers()
             ),
         command_decl!(
             arg!(--dlayer [X] "Set target layer for draw operations"),

--- a/crates/vsvg-viewer/src/document_widget.rs
+++ b/crates/vsvg-viewer/src/document_widget.rs
@@ -233,8 +233,8 @@ impl DocumentWidget {
                 let mut viewer_options = self.viewer_options.lock().unwrap();
                 let visibility = viewer_options.layer_visibility.entry(*lid).or_insert(true);
                 let mut label = format!("Layer {lid}");
-                if !layer.metadata().name.is_empty() {
-                    label.push_str(&format!(": {}", layer.metadata().name));
+                if let Some(name) = &layer.metadata().name {
+                    label.push_str(&format!(": {name}"));
                 }
 
                 ui.checkbox(visibility, label);

--- a/crates/vsvg/examples/basic.rs
+++ b/crates/vsvg/examples/basic.rs
@@ -9,7 +9,7 @@ fn main() {
 
     /* == Layers == */
     let mut layer = vsvg::Layer::default();
-    layer.metadata_mut().name = "Layer 2".to_string();
+    layer.metadata_mut().name = Some("Layer 2".to_string());
 
     // vsvg uses kurbo internally, and its API is compatible with it
     layer.push_path(kurbo::Circle::new((50., 50.), 30.));

--- a/crates/vsvg/src/document/mod.rs
+++ b/crates/vsvg/src/document/mod.rs
@@ -49,14 +49,14 @@ pub trait DocumentTrait<L: LayerTrait<P, D>, P: PathTrait<D>, D: PathDataTrait>:
         self.layers_mut().values_mut().for_each(f);
     }
 
-    /// Merge all existing layers into layer 1, if any.
+    /// Merge all existing layers into layer 0, if any.
     fn merge_layers(&mut self) {
         if let Some((_, mut layer)) = self.layers_mut().pop_first() {
             while let Some((_, other)) = self.layers_mut().pop_first() {
                 layer.merge(&other);
             }
 
-            self.layers_mut().insert(1, layer);
+            self.layers_mut().insert(0, layer);
         }
     }
 

--- a/crates/vsvg/src/document/mod.rs
+++ b/crates/vsvg/src/document/mod.rs
@@ -49,6 +49,17 @@ pub trait DocumentTrait<L: LayerTrait<P, D>, P: PathTrait<D>, D: PathDataTrait>:
         self.layers_mut().values_mut().for_each(f);
     }
 
+    /// Merge all existing layers into layer 1, if any.
+    fn merge_layers(&mut self) {
+        if let Some((_, mut layer)) = self.layers_mut().pop_first() {
+            while let Some((_, other)) = self.layers_mut().pop_first() {
+                layer.merge(&other);
+            }
+
+            self.layers_mut().insert(1, layer);
+        }
+    }
+
     #[must_use]
     fn bounds(&self) -> Option<kurbo::Rect> {
         if self.layers().is_empty() {

--- a/crates/vsvg/src/layer/flattened_layer.rs
+++ b/crates/vsvg/src/layer/flattened_layer.rs
@@ -9,11 +9,6 @@ pub struct FlattenedLayer {
 
 impl FlattenedLayer {
     #[must_use]
-    pub fn new(paths: Vec<FlattenedPath>, metadata: LayerMetadata) -> Self {
-        Self { paths, metadata }
-    }
-
-    #[must_use]
     pub fn vertex_count(&self) -> u64 {
         self.paths
             .iter()
@@ -31,6 +26,10 @@ impl Transforms for FlattenedLayer {
     }
 }
 impl LayerTrait<FlattenedPath, Polyline> for FlattenedLayer {
+    fn from_paths_and_metadata(paths: Vec<FlattenedPath>, metadata: LayerMetadata) -> Self {
+        Self { paths, metadata }
+    }
+
     fn paths(&self) -> &[FlattenedPath] {
         &self.paths
     }

--- a/crates/vsvg/src/layer/layer.rs
+++ b/crates/vsvg/src/layer/layer.rs
@@ -8,15 +8,6 @@ pub struct Layer {
     metadata: LayerMetadata,
 }
 
-impl Layer {
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
-    }
-}
-
 impl Transforms for Layer {
     fn transform(&mut self, affine: &kurbo::Affine) -> &mut Self {
         self.paths.par_iter_mut().for_each(|path| {
@@ -27,6 +18,10 @@ impl Transforms for Layer {
 }
 
 impl LayerTrait<Path, kurbo::BezPath> for Layer {
+    fn from_paths_and_metadata(paths: Vec<Path>, metadata: LayerMetadata) -> Self {
+        Self { paths, metadata }
+    }
+
     fn paths(&self) -> &[Path] {
         &self.paths
     }
@@ -55,14 +50,14 @@ impl Layer {
             .flat_map(|path| path.flatten(tolerance))
             .collect();
 
-        FlattenedLayer::new(flattened_paths, self.metadata.clone())
+        FlattenedLayer::from_paths_and_metadata(flattened_paths, self.metadata.clone())
     }
 
     #[must_use]
     pub fn bezier_handles(&self) -> FlattenedLayer {
         crate::trace_function!();
 
-        FlattenedLayer::new(
+        FlattenedLayer::from_paths_and_metadata(
             self.paths
                 .par_iter()
                 .flat_map(Path::bezier_handles)

--- a/crates/vsvg/src/layer/metadata.rs
+++ b/crates/vsvg/src/layer/metadata.rs
@@ -1,4 +1,16 @@
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct LayerMetadata {
-    pub name: String,
+    pub name: Option<String>,
+    //TODO(#4): add default path metadata
+}
+
+impl LayerMetadata {
+    /// Merge with another [`LayerMetadata`].
+    ///
+    /// Only the common attributes are kept, the other are discarded.
+    pub fn merge(&mut self, other: &Self) {
+        if self.name != other.name {
+            self.name = None;
+        }
+    }
 }

--- a/crates/vsvg/src/layer/mod.rs
+++ b/crates/vsvg/src/layer/mod.rs
@@ -11,6 +11,14 @@ pub use layer::Layer;
 pub use metadata::LayerMetadata;
 
 pub trait LayerTrait<P: PathTrait<D>, D: PathDataTrait>: Default + Transforms {
+    #[must_use]
+    fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    fn from_paths_and_metadata(paths: Vec<P>, metadata: LayerMetadata) -> Self;
+
     fn paths(&self) -> &[P];
 
     fn paths_mut(&mut self) -> &mut Vec<P>;
@@ -35,6 +43,15 @@ pub trait LayerTrait<P: PathTrait<D>, D: PathDataTrait>: Default + Transforms {
 
     fn push_path(&mut self, path: impl Into<P>) {
         self.paths_mut().push(path.into());
+    }
+
+    /// Merge another layer into this one.
+    ///
+    /// Also merges the metadata, see [`LayerMetadata::merge`].
+    fn merge(&mut self, other: &Self) {
+        self.paths_mut().extend_from_slice(other.paths());
+        self.metadata_mut().merge(other.metadata());
+        //TODO(#4): merge default path metadata and cascade difference to paths
     }
 
     fn sort(&mut self, flip: bool) {

--- a/crates/vsvg/src/svg/reader.rs
+++ b/crates/vsvg/src/svg/reader.rs
@@ -232,10 +232,7 @@ impl Document {
                     let layer = self.get_mut(layer_id.unwrap_or(top_level_index));
                     parse_group(&child, &transform, layer);
 
-                    // set layer name
-                    if let Some(name) = layer_name {
-                        layer.metadata_mut().name = name.clone();
-                    }
+                    layer.metadata_mut().name = layer_name;
                 }
                 usvg::NodeKind::Path(ref path) => {
                     self.get_mut(0)
@@ -315,11 +312,26 @@ mod tests {
         .unwrap();
 
         assert_eq!(doc.layers.len(), 5);
-        assert_eq!(doc.try_get(10).unwrap().metadata().name, "Layer 10");
-        assert_eq!(doc.try_get(11).unwrap().metadata().name, "layer11");
-        assert_eq!(doc.try_get(3).unwrap().metadata().name, "Hello");
-        assert_eq!(doc.try_get(4).unwrap().metadata().name, "world");
-        assert_eq!(doc.try_get(5).unwrap().metadata().name, "layer_name");
+        assert_eq!(
+            doc.try_get(10).unwrap().metadata().name,
+            Some("Layer 10".to_owned())
+        );
+        assert_eq!(
+            doc.try_get(11).unwrap().metadata().name,
+            Some("layer11".to_owned())
+        );
+        assert_eq!(
+            doc.try_get(3).unwrap().metadata().name,
+            Some("Hello".to_owned())
+        );
+        assert_eq!(
+            doc.try_get(4).unwrap().metadata().name,
+            Some("world".to_owned())
+        );
+        assert_eq!(
+            doc.try_get(5).unwrap().metadata().name,
+            Some("layer_name".to_owned())
+        );
     }
 
     #[test]
@@ -347,9 +359,18 @@ mod tests {
 
         assert_eq!(doc.layers.len(), 4);
         assert_eq!(doc.try_get(0).unwrap().paths.len(), 1);
-        assert_eq!(doc.try_get(1).unwrap().metadata().name, "layer_one");
-        assert_eq!(doc.try_get(11).unwrap().metadata().name, "layer11");
-        assert_eq!(doc.try_get(3).unwrap().metadata().name, "layer_three");
+        assert_eq!(
+            doc.try_get(1).unwrap().metadata().name,
+            Some("layer_one".to_owned())
+        );
+        assert_eq!(
+            doc.try_get(11).unwrap().metadata().name,
+            Some("layer11".to_owned())
+        );
+        assert_eq!(
+            doc.try_get(3).unwrap().metadata().name,
+            Some("layer_three".to_owned())
+        );
     }
 
     #[test]

--- a/crates/vsvg/src/svg/writer.rs
+++ b/crates/vsvg/src/svg/writer.rs
@@ -79,9 +79,11 @@ fn path_to_svg_path<P: PathTrait<D>, D: PathDataTrait>(path: &P) -> svg::node::e
 fn layer_to_svg_group<L: LayerTrait<P, D>, P: PathTrait<D>, D: PathDataTrait + SvgPathWriter>(
     layer: &L,
 ) -> svg::node::element::Group {
-    let mut group = svg::node::element::Group::new()
-        .set("inkscape:groupmode", "layer")
-        .set("inkscape:label", layer.metadata().name.as_str());
+    let mut group = svg::node::element::Group::new().set("inkscape:groupmode", "layer");
+
+    if let Some(name) = &layer.metadata().name {
+        group = group.set("inkscape:label", name.as_str());
+    }
 
     for path in layer.paths() {
         group = group.add(path_to_svg_path(path));


### PR DESCRIPTION
This operation simply merges all layers to layer 0, if any (ie `lmove all 0` in vpype's parlance).

To use with the CLI:
```
vsvg --layermerge true path/to/file.svg
```

This PR doesn't include refinement such as:
- copying instead of moving (`lcopy`)
- moving only _some_ layers
- choosing the target destination

Also, it will need to properly handle path meta data cascading when that is a thing (#4).