### PR TITLE
Add support for custom `struct` as sketch parameter

### DIFF
--- a/crates/whiskers-derive/Cargo.toml
+++ b/crates/whiskers-derive/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.37", features = ["full"] }
+syn = { version = "2.0.37", features = ["full", "visit-mut"] }
 quote = "1.0.33"
 proc-macro2 = "1.0.67"
 convert_case.workspace = true

--- a/crates/whiskers-derive/src/lib.rs
+++ b/crates/whiskers-derive/src/lib.rs
@@ -1,7 +1,11 @@
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
-use quote::quote;
-use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Expr, Fields, FieldsNamed};
+use proc_macro2::Ident;
+use quote::{format_ident, quote};
+use syn::{
+    parse_macro_input, parse_quote, visit_mut::VisitMut, Data, DataStruct, DeriveInput, Expr,
+    ExprPath, Fields, FieldsNamed, FieldsUnnamed, Index,
+};
 
 fn format_label(label: &str) -> String {
     format!("{}:", label.to_case(Case::Lower))
@@ -13,66 +17,12 @@ pub fn sketch_derive(input: TokenStream) -> TokenStream {
 
     let name = input.ident;
 
-    let mut ui_func_tokens = proc_macro2::TokenStream::new();
-
-    match input.data {
-        Data::Struct(DataStruct { fields, .. }) => match fields {
-            Fields::Named(FieldsNamed { named, .. }) => {
-                for field in named {
-                    let field_name = field.ident.unwrap();
-                    let field_type = field.ty;
-                    let label = field_name.to_string();
-
-                    let skip_attr = field.attrs.iter().find(|attr| attr.path().is_ident("skip"));
-                    if skip_attr.is_some() {
-                        continue;
-                    }
-
-                    let param_attr = field
-                        .attrs
-                        .iter()
-                        .find(|attr| attr.path().is_ident("param"));
-
-                    let mut chained_calls = proc_macro2::TokenStream::new();
-
-                    if let Some(param_attr) = param_attr {
-                        let res = param_attr.parse_nested_meta(|meta| {
-                            let ident = meta.path.get_ident().expect("expected ident");
-                            let value = meta.value();
-
-                            if value.is_ok() {
-                                let expr: Expr = meta.input.parse()?;
-                                chained_calls.extend(quote! {
-                                    .#ident(#expr)
-                                });
-                            } else {
-                                chained_calls.extend(quote! {
-                                    .#ident(true)
-                                });
-                            }
-
-                            Ok(())
-                        });
-
-                        if res.is_err() {
-                            panic!("failed to parse param attribute");
-                        }
-                    }
-
-                    let formatted_label = format_label(&label);
-
-                    ui_func_tokens.extend(quote! {
-                        changed = <#field_type as ::whiskers::widgets::WidgetMapper<#field_type>>::Type::default()
-                            #chained_calls
-                            .ui(ui, #formatted_label, &mut self.#field_name).changed() || changed;
-                        ui.end_row();
-                    });
-                }
-            }
-            _ => panic!("The Sketch derive macro only supports named-field structs"),
-        },
+    let fields_ui = match input.data {
+        Data::Struct(DataStruct { fields, .. }) => {
+            process_fields(fields, &format_ident!("Self"), &format_ident!("self"))
+        }
         _ => panic!("The Sketch derive macro only supports structs"),
-    }
+    };
 
     TokenStream::from(quote! {
         impl ::whiskers::SketchApp for #name {
@@ -81,10 +31,178 @@ pub fn sketch_derive(input: TokenStream) -> TokenStream {
             }
 
             fn ui(&mut self, ui: &mut ::whiskers::prelude::egui::Ui) -> bool {
-                let mut changed = false;
-                #ui_func_tokens
-                changed
+                #fields_ui
             }
         }
     })
+}
+
+#[proc_macro_derive(Widget, attributes(param, skip))]
+pub fn sketch_ui_derive(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = parse_macro_input!(input);
+
+    let name = input.ident;
+    let widget_name = format_ident!("{}Widget", name);
+
+    let fields_ui = match input.data {
+        Data::Struct(DataStruct { fields, .. }) => {
+            process_fields(fields, &name, &format_ident!("value"))
+        }
+        _ => panic!("The Sketch derive macro only supports structs"),
+    };
+
+    TokenStream::from(quote! {
+        #[derive(Default)]
+        pub struct #widget_name;
+
+        impl ::whiskers::widgets::Widget<#name> for #widget_name {
+            fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut #name) -> bool {
+                ::whiskers::collapsing_header(ui, label.trim_end_matches(':'), "", true, |ui|{
+                        #fields_ui
+                    })
+                    .unwrap_or(false)
+            }
+
+            fn use_grid() -> bool {
+                false
+            }
+        }
+
+        impl ::whiskers::widgets::WidgetMapper<#name> for #name {
+            type Type = #widget_name;
+        }
+    })
+}
+
+fn process_fields(
+    fields: Fields,
+    parent_type: &Ident,
+    parent_var: &Ident,
+) -> proc_macro2::TokenStream {
+    let mut output = proc_macro2::TokenStream::new();
+
+    let fields = match fields {
+        Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => unnamed,
+        Fields::Named(FieldsNamed { named, .. }) => named,
+        _ => panic!("The Sketch derive macro only supports named-field structs"),
+    };
+
+    for (idx, field) in fields.into_iter().enumerate() {
+        let (field_name, field_access) = match field.ident {
+            Some(ident) => (ident.clone(), quote!(#ident)),
+            None => {
+                let i = Index::from(idx);
+                (format_ident!("field_{}", idx), quote!(#i))
+            }
+        };
+
+        let field_type = field.ty;
+        let label = field_name.to_string();
+
+        let skip_attr = field.attrs.iter().find(|attr| attr.path().is_ident("skip"));
+        if skip_attr.is_some() {
+            continue;
+        }
+
+        let param_attr = field
+            .attrs
+            .iter()
+            .find(|attr| attr.path().is_ident("param"));
+
+        let mut chained_calls = proc_macro2::TokenStream::new();
+
+        if let Some(param_attr) = param_attr {
+            let res = param_attr.parse_nested_meta(|meta| {
+                let ident = meta.path.get_ident().expect("expected ident");
+                let value = meta.value();
+
+                if value.is_ok() {
+                    let mut expr: Expr = meta.input.parse()?;
+
+                    // replaces occurrences of self with obj
+                    ReplaceSelf.visit_expr_mut(&mut expr);
+
+                    chained_calls.extend(quote! {
+                        .#ident(#expr)
+                    });
+                } else {
+                    chained_calls.extend(quote! {
+                        .#ident(true)
+                    });
+                }
+
+                Ok(())
+            });
+
+            if res.is_err() {
+                panic!("failed to parse param attribute");
+            }
+        }
+
+        let formatted_label = format_label(&label);
+
+        output.extend(quote! {
+            (
+                &|ui, obj| {
+                    <#field_type as ::whiskers::widgets::WidgetMapper<#field_type>>::Type::default()
+                        #chained_calls
+                        .ui(ui, #formatted_label, &mut obj.#field_access)
+
+                },
+                &<#field_type as ::whiskers::widgets::WidgetMapper<#field_type>>::Type::use_grid,
+            ),
+        });
+    }
+
+    // This is the magic UI code that handles `whiskers::widgets::Widget::use_grid()`. It works as
+    // follows:
+    // - An array of closure tuple are created for all fields. The first closure is the actual UI
+    //   code, the second is a predicate that returns whether the grid should be used.
+    // - The array is then walked, and contiguous stretches of tuple for which the predicate returns
+    //   `true` grouped together and rendered in a grid.
+    quote! {
+        {
+            let array: &[(
+                &dyn Fn(&mut egui::Ui, &mut #parent_type) -> bool, // ui code
+                &dyn Fn() -> bool                                  // use grid predicate
+            )] = &[
+                #output
+            ];
+
+            let mut cur_index = 0;
+            let mut changed = false;
+
+            while cur_index < array.len() {
+                if array[cur_index].1() {
+                    egui::Grid::new(cur_index)
+                        .num_columns(2)
+                        .show(ui, |ui| {
+                            while cur_index < array.len() && array[cur_index].1() {
+                                changed = (array[cur_index].0)(ui, #parent_var) || changed;
+                                ui.end_row();
+                                cur_index += 1;
+                            }
+                        });
+                }
+
+                while cur_index < array.len() && !array[cur_index].1() {
+                    changed = (array[cur_index].0)(ui, #parent_var) || changed;
+                    cur_index += 1;
+                }
+            }
+
+            changed
+        }
+    }
+}
+
+/// Expression visitor to replace `self` with `obj`.
+struct ReplaceSelf;
+
+impl VisitMut for ReplaceSelf {
+    fn visit_expr_path_mut(&mut self, node: &mut ExprPath) {
+        if node.path.is_ident("self") {
+            *node = parse_quote!(obj);
+        }
+    }
 }

--- a/crates/whiskers/examples/custom_ui.rs
+++ b/crates/whiskers/examples/custom_ui.rs
@@ -16,7 +16,8 @@ impl From<GrayRed> for vsvg::Color {
     }
 }
 
-/// Custom UI widget for [`GreyRed`]. It must implement the [`Widget<GrayRed>`] trait.
+/// Custom UI widget for [`GreyRed`]. It must implement the [`whiskers::widgets::Widget<GrayRed>`]
+/// trait.
 #[derive(Default)]
 struct GrayRedWidget {
     label_color: egui::Color32,
@@ -37,8 +38,8 @@ impl GrayRedWidget {
 }
 
 /// This is where the custom UI code happens.
-impl Widget<GrayRed> for GrayRedWidget {
-    fn ui(&self, ui: &mut Ui, label: &str, value: &mut GrayRed) -> egui::Response {
+impl whiskers::widgets::Widget<GrayRed> for GrayRedWidget {
+    fn ui(&self, ui: &mut Ui, label: &str, value: &mut GrayRed) -> bool {
         let mut label = egui::RichText::new(label).color(self.label_color);
         if self.underline {
             label = label.underline();
@@ -49,24 +50,30 @@ impl Widget<GrayRed> for GrayRedWidget {
         // the labels. It is thus important that we render only *two* top-level `ui` calls. Here, we
         // have the label and the `ui.vertical()` call, so we're good.
 
+        // Note: for more complex UI, it's possible to override `use_grid()` and return `false`.
+        // In this case, the two-column grid will not be used for this widget.
+
         ui.vertical(|ui| {
-            let resp1 = ui
+            let mut changed = false;
+            changed = ui
                 .horizontal(|ui| {
                     ui.label("gr:");
                     ui.add(egui::Slider::new(&mut value.gray, 0.0..=1.0))
                 })
-                .inner;
+                .inner
+                .changed()
+                || changed;
 
-            let resp2 = ui
+            changed = ui
                 .horizontal(|ui| {
                     ui.label("rd:");
                     ui.add(egui::Slider::new(&mut value.red, 0.0..=1.0))
                 })
-                .inner;
+                .inner
+                .changed()
+                || changed;
 
-            // we must return a response that combines the responses of the sub-widgets to make
-            // sure any change to the slider are reported
-            resp1 | resp2
+            changed
         })
         .inner
     }

--- a/crates/whiskers/examples/ui_demo.rs
+++ b/crates/whiskers/examples/ui_demo.rs
@@ -1,0 +1,70 @@
+//! This example demonstrates all UI building capabilities of the [`derive@Sketch`] and
+//! [`derive@Widget`] derived traits.
+
+use whiskers::prelude::*;
+
+#[derive(Sketch, Default)]
+struct UiDemoSketch {
+    // all basic numerical types are supported
+    int_64: i64,
+
+    // numerical types can be configured with the `#[param(...)]` attribute
+    #[param(min = 0, max = 100)]
+    int_0_to_100: i8,
+
+    // other fields may be used
+    #[param(min = 0, max = self.int_0_to_100)]
+    int_variable_bound: i8,
+
+    // a slider can be used instead of a DragValue
+    #[param(slider, min = 0.0, max = 100.0)]
+    float_0_to_100: f32,
+
+    // a logarithmic slider can be used also
+    #[param(slider, logarithmic, min = 0.01, max = 10.)]
+    float_log: f64,
+
+    // custom types
+    custom_struct: CustomStruct,
+    custom_struct_unnamed: CustomStructUnnamed,
+
+    // these types are supported but have no configuration options
+    boolean: bool,
+    string: String,
+    color: Color,
+    point: Point,
+}
+
+// Custom types may be used as sketch parameter if a corresponding [`whiskers::widgets::Widget`]
+// type exists. This can be done using the [`whiskers_derive::Widget`] derive macro. Alternatively,
+// the [`whiskers::widgets::WidgetMapper`] trait can be implemented manually, see the `custom_ui`
+// example.
+// Note: all types must implement [`Default`].
+#[derive(Widget, Default)]
+struct CustomStruct {
+    #[param(min = 0.0)]
+    some_float: f64,
+
+    #[param(min = 0.0, max = self.some_float)]
+    another_float: f64,
+
+    // nested struct are supported
+    custom_struct_unnamed: CustomStructUnnamed,
+}
+
+// Tuple structs are supported too
+#[derive(Widget, Default)]
+struct CustomStructUnnamed(bool, String);
+
+impl App for UiDemoSketch {
+    fn update(&mut self, _sketch: &mut Sketch, _ctx: &mut Context) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+fn main() -> Result {
+    Runner::new(UiDemoSketch::default())
+        .with_page_size_options(PageSize::A5H)
+        .with_layout_options(LayoutOptions::Center)
+        .run()
+}

--- a/crates/whiskers/src/lib.rs
+++ b/crates/whiskers/src/lib.rs
@@ -110,7 +110,9 @@ pub use grid_helpers::{
     grid::{Grid, GridCell},
     hex_grid::{cell::HexGridCell, HexGrid},
 };
-pub use runner::{AnimationOptions, InfoOptions, LayoutOptions, PageSizeOptions, Runner};
+pub use runner::{
+    collapsing_header, AnimationOptions, InfoOptions, LayoutOptions, PageSizeOptions, Runner,
+};
 pub use sketch::Sketch;
 
 /// This is a convenience alias to the [`anyhow::Result`] type, which you can use for your sketch's

--- a/crates/whiskers/src/prelude.rs
+++ b/crates/whiskers/src/prelude.rs
@@ -1,10 +1,10 @@
+pub use crate::widgets::Widget as _; // bring trait in scope, but avoid name-clash with macro
 pub use crate::{
-    register_widget_ui, wasm_sketch, widgets::Widget, AnimationOptions, App, Context, Grid,
-    GridCell, HexGrid, HexGridCell, InfoOptions, LayoutOptions, PageSizeOptions, Result, Runner,
-    Sketch,
+    register_widget_ui, wasm_sketch, AnimationOptions, App, Context, Grid, GridCell, HexGrid,
+    HexGridCell, InfoOptions, LayoutOptions, PageSizeOptions, Result, Runner, Sketch,
 };
 pub use vsvg::{Color, Draw, IntoBezPath, IntoBezPathTolerance, PageSize, Point, Transforms, Unit};
-pub use whiskers_derive::Sketch;
+pub use whiskers_derive::{Sketch, Widget};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use vsvg_viewer::show;

--- a/crates/whiskers/src/runner/mod.rs
+++ b/crates/whiskers/src/runner/mod.rs
@@ -234,6 +234,7 @@ impl vsvg_viewer::ViewerApp for Runner<'_> {
             .default_width(200.)
             .show(ctx, |ui| {
                 ui.spacing_mut().item_spacing.y = 6.0;
+                ui.spacing_mut().indent = 14.0;
                 ui.spacing_mut().slider_width = 170.0;
                 ui.visuals_mut().slider_trailing_fill = true;
                 ui.visuals_mut().collapsing_header_frame = true;
@@ -263,10 +264,7 @@ impl vsvg_viewer::ViewerApp for Runner<'_> {
                             self.save_ui.ui(ui, self.last_document.clone());
 
                             collapsing_header(ui, "Sketch Parameters", "", true, |ui| {
-                                let changed = egui::Grid::new("sketch_param_grid")
-                                    .num_columns(2)
-                                    .show(ui, |ui| self.app.ui(ui))
-                                    .inner;
+                                let changed = self.app.ui(ui);
                                 self.set_dirty(changed);
                             });
                         })

--- a/crates/whiskers/src/widgets/bool.rs
+++ b/crates/whiskers/src/widgets/bool.rs
@@ -3,11 +3,11 @@
 pub struct BoolWidget;
 
 impl super::Widget<bool> for BoolWidget {
-    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut bool) -> egui::Response {
+    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut bool) -> bool {
         // empty first column
         ui.horizontal(|_| {});
 
-        ui.checkbox(value, label.trim_end_matches(':'))
+        ui.checkbox(value, label.trim_end_matches(':')).changed()
     }
 }
 

--- a/crates/whiskers/src/widgets/color.rs
+++ b/crates/whiskers/src/widgets/color.rs
@@ -3,7 +3,7 @@
 pub struct ColorWidget;
 
 impl super::Widget<vsvg::Color> for ColorWidget {
-    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut vsvg::Color) -> egui::Response {
+    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut vsvg::Color) -> bool {
         // empty first column
         ui.label(label);
 
@@ -13,7 +13,7 @@ impl super::Widget<vsvg::Color> for ColorWidget {
             *value = color_components.into();
         }
 
-        resp
+        resp.changed()
     }
 }
 

--- a/crates/whiskers/src/widgets/mod.rs
+++ b/crates/whiskers/src/widgets/mod.rs
@@ -113,9 +113,16 @@ pub use string::*;
 pub trait Widget<T> {
     /// This function implements the actual UI for the widget.
     ///
-    /// Note that the [`crate::Runner`] calls this function in the context of a 2-column
-    /// [`egui::Grid`], so it must contain exactly two top level egui UI calls.
-    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut T) -> egui::Response;
+    /// Returns [`true`] if the value was changed.
+    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut T) -> bool;
+
+    /// Indicates whether the widget should be displayed in a two-column grid.
+    ///
+    /// Complex and/or compound widgets which cannot fit the two-column grid layout should return
+    /// [`false`].
+    fn use_grid() -> bool {
+        true
+    }
 }
 
 /// This utility trait serves to associate a [`Widget`] type with a given sketch parameter type `T`.

--- a/crates/whiskers/src/widgets/numeric.rs
+++ b/crates/whiskers/src/widgets/numeric.rs
@@ -56,7 +56,7 @@ impl<T: Numeric> NumericWidget<T> {
 }
 
 impl<T: Numeric> super::Widget<T> for NumericWidget<T> {
-    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut T) -> egui::Response {
+    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut T) -> bool {
         ui.add(egui::Label::new(label));
         let range = self.min.unwrap_or(T::MIN)..=self.max.unwrap_or(T::MAX);
         if self.slider {
@@ -67,13 +67,13 @@ impl<T: Numeric> super::Widget<T> for NumericWidget<T> {
             if self.logarithmic {
                 slider = slider.logarithmic(true);
             }
-            ui.add(slider)
+            ui.add(slider).changed()
         } else {
             let mut drag_value = egui::DragValue::new(value).clamp_range(range);
             if let Some(step) = self.step {
                 drag_value = drag_value.speed(step.to_f64());
             }
-            ui.add(drag_value)
+            ui.add(drag_value).changed()
         }
     }
 }

--- a/crates/whiskers/src/widgets/point.rs
+++ b/crates/whiskers/src/widgets/point.rs
@@ -1,4 +1,4 @@
-use egui::{Response, Ui};
+use egui::Ui;
 use vsvg::Point;
 
 /// Widget for the [`Point`] type.
@@ -6,13 +6,14 @@ use vsvg::Point;
 pub struct PointWidget;
 
 impl super::Widget<Point> for PointWidget {
-    fn ui(&self, ui: &mut Ui, label: &str, value: &mut Point) -> Response {
+    fn ui(&self, ui: &mut Ui, label: &str, value: &mut Point) -> bool {
         ui.add(egui::Label::new(label));
         ui.horizontal(|ui| {
             ui.add(egui::DragValue::new(value.x_mut()).speed(0.1))
                 | ui.add(egui::DragValue::new(value.y_mut()).speed(0.1))
         })
         .inner
+        .changed()
     }
 }
 

--- a/crates/whiskers/src/widgets/string.rs
+++ b/crates/whiskers/src/widgets/string.rs
@@ -3,9 +3,9 @@
 pub struct StringWidget;
 
 impl super::Widget<String> for StringWidget {
-    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut String) -> egui::Response {
+    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut String) -> bool {
         ui.add(egui::Label::new(label));
-        ui.add(egui::TextEdit::singleline(value))
+        ui.add(egui::TextEdit::singleline(value)).changed()
     }
 }
 


### PR DESCRIPTION
This PR adds support for custom `struct` (both with named and unnamed fields) to be used as sketch parameter. This is done via the new `Widget` derive macro:

```rust
#[derive(Sketch, Default)]
struct DemoSketch {
    custom_struct: CustomStruct,
}

#[derive(Widget, Default)]
struct CustomStruct {
   #[param(slider, min = 0.0, max = 10.0)]
   my_param: f64,
}
```

Nesting is supported.

A new `ui_demo.rs` example is introduced to demonstrate/test all supported types and combinations.