### PR TITLE
Improve `ViewerApp` hooks to give implementers more flexibility

### DIFF
--- a/crates/msvg/src/main.rs
+++ b/crates/msvg/src/main.rs
@@ -91,7 +91,7 @@ impl ViewerApp for MsvgViewerApp {
         Ok(())
     }
 
-    fn update(
+    fn show_panels(
         &mut self,
         ctx: &egui::Context,
         document_widget: &mut DocumentWidget,

--- a/crates/vsvg-viewer/examples/custom_panel.rs
+++ b/crates/vsvg-viewer/examples/custom_panel.rs
@@ -30,7 +30,7 @@ impl ViewerApp for SidePanelViewerApp {
         Ok(())
     }
 
-    fn update(
+    fn show_panels(
         &mut self,
         ctx: &egui::Context,
         document_widget: &mut DocumentWidget,

--- a/crates/vsvg-viewer/src/document_widget.rs
+++ b/crates/vsvg-viewer/src/document_widget.rs
@@ -91,7 +91,10 @@ impl DocumentWidget {
     pub fn ui(&mut self, ui: &mut Ui) {
         vsvg::trace_function!();
 
-        let (rect, response) = ui.allocate_exact_size(ui.available_size(), Sense::click_and_drag());
+        // do not actually allocate any space, so custom viewer code may use all of the central
+        // panel
+        let rect = ui.available_rect_before_wrap();
+        let response = ui.interact(rect, ui.id(), Sense::click_and_drag());
 
         // fit to view on request
         if self.must_fit_to_view {

--- a/crates/vsvg-viewer/src/lib.rs
+++ b/crates/vsvg-viewer/src/lib.rs
@@ -93,12 +93,23 @@ pub trait ViewerApp {
         Ok(())
     }
 
-    /// Main update hook
+    /// Hook to show side panels
     ///
-    /// Create side panels for UI and/or update the document widget.
-    fn update(
+    /// This hook is called before the central panel is drawn, as per the [`egui`] documentation.
+    fn show_panels(
         &mut self,
         _ctx: &egui::Context,
+        _document_widget: &mut DocumentWidget,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Hook to show the central panel.
+    ///
+    /// This is call after the wgpu render callback that displays the document.
+    fn show_central_panel(
+        &mut self,
+        _ui: &mut egui::Ui,
         _document_widget: &mut DocumentWidget,
     ) -> anyhow::Result<()> {
         Ok(())

--- a/crates/vsvg-viewer/src/viewer.rs
+++ b/crates/vsvg-viewer/src/viewer.rs
@@ -169,19 +169,26 @@ impl eframe::App for Viewer {
             });
         });
 
+        // hook for creating side panels
+        //TODO: better error management
+        self.viewer_app
+            .show_panels(ctx, &mut self.document_widget)
+            .expect("ViewerApp failed!!!");
+
         let panel_frame = egui::Frame::central_panel(&ctx.style())
             .inner_margin(egui::style::Margin::same(0.))
             .fill(Color32::from_rgb(242, 242, 242));
 
-        // hook for creating side panels
-        //TODO: better error management
-        self.viewer_app
-            .update(ctx, &mut self.document_widget)
-            .expect("ViewerApp failed!!!");
-
         egui::CentralPanel::default()
             .frame(panel_frame)
-            .show(ctx, |ui| self.document_widget.ui(ui));
+            .show(ctx, |ui| {
+                self.document_widget.ui(ui);
+
+                //TODO: better error management
+                self.viewer_app
+                    .show_central_panel(ui, &mut self.document_widget)
+                    .expect("ViewerApp failed!!!");
+            });
 
         egui::Window::new("🔧 Settings")
             .open(&mut self.state.show_settings)

--- a/crates/whiskers/src/runner/mod.rs
+++ b/crates/whiskers/src/runner/mod.rs
@@ -219,7 +219,7 @@ impl Runner<'_> {
 }
 
 impl vsvg_viewer::ViewerApp for Runner<'_> {
-    fn update(
+    fn show_panels(
         &mut self,
         ctx: &egui::Context,
         document_widget: &mut DocumentWidget,


### PR DESCRIPTION
In particular:
- add a hook to draw stuff on the central panel
- change `DocumentWidget` to not egui-allocate anything, so that the entire central panel is available for drawing

See #70 for future improvements

