### PR TITLE
Change `HexGrid::spacing()` to accept a single scalar and maintain hexagonal grid

### DIFF
--- a/crates/whiskers/examples/hex_grid.rs
+++ b/crates/whiskers/examples/hex_grid.rs
@@ -39,7 +39,7 @@ impl App for HexGridSketch {
         grid.cell_size(self.cell_size)
             .columns(self.columns)
             .rows(self.rows)
-            .spacing([self.spacing, self.spacing])
+            .spacing(self.spacing)
             .build(sketch, |sketch, cell| {
                 sketch.add_path(cell);
             });

--- a/crates/whiskers/src/grid_helpers/hex_grid/mod.rs
+++ b/crates/whiskers/src/grid_helpers/hex_grid/mod.rs
@@ -81,7 +81,7 @@ impl HexGrid {
         let triangle_h = 0.5 * 3.0_f64.sqrt();
         self.gutter = match self.orientation {
             Orientation::Flat => [value * triangle_h, value],
-            Orientation::Pointy => [value, value * triangle_h]
+            Orientation::Pointy => [value, value * triangle_h],
         };
         self
     }

--- a/crates/whiskers/src/grid_helpers/hex_grid/mod.rs
+++ b/crates/whiskers/src/grid_helpers/hex_grid/mod.rs
@@ -77,8 +77,12 @@ impl HexGrid {
     /// Overrides grid's current horizontal and vertical spacing values.
     /// By default, grid instance will have zero spacing on both axes.
     #[must_use]
-    pub fn spacing(mut self, value: [f64; 2]) -> Self {
-        self.gutter = value;
+    pub fn spacing(mut self, value: f64) -> Self {
+        let triangle_h = 0.5 * 3.0_f64.sqrt();
+        self.gutter = match self.orientation {
+            Orientation::Flat => [value * triangle_h, value],
+            Orientation::Pointy => [value, value * triangle_h]
+        };
         self
     }
 
@@ -124,20 +128,20 @@ impl HexGrid {
                 let is_even_row = row % 2 == 0;
                 let x: f64;
                 let y: f64;
-                let gutter_x = self.gutter[0] * column as f64;
-                let gutter_y = self.gutter[1] * row as f64;
+                let gutter_x = self.gutter[0];
+                let gutter_y = self.gutter[1];
 
                 match self.orientation {
                     Orientation::Flat => {
                         horiz = cell_size_one_half;
                         vert = sqrt_three * self.cell_size;
 
-                        x = horiz * column as f64 + gutter_x;
+                        x = (gutter_x + horiz) * column as f64;
                         y = if is_even_col {
-                            vert * row as f64
+                            (vert + gutter_y) * row as f64
                         } else {
-                            vert * row as f64 + (vert / 2.0)
-                        } + gutter_y;
+                            (vert + gutter_y) * (row as f64 + 0.5)
+                        };
 
                         cell = HexGridCell::with_flat_orientation();
                     }
@@ -146,11 +150,11 @@ impl HexGrid {
                         vert = cell_size_one_half;
 
                         x = if is_even_row {
-                            horiz * column as f64
+                            (horiz + gutter_x) * column as f64
                         } else {
-                            horiz * column as f64 + (horiz / 2.0)
-                        } + gutter_x;
-                        y = (vert * row as f64 + vert) + gutter_y;
+                            (horiz + gutter_x) * (column as f64 + 0.5)
+                        };
+                        y = (vert + gutter_y) * row as f64;
 
                         cell = HexGridCell::with_pointy_orientation();
                     }


### PR DESCRIPTION
Keep the hexagons placed within hexagon grid when setting spacing. Previous version placed them in rectangular grid.

Note that it does change the argument type for spacing function arguments from `[f64; 2]` to `f64` it is still possible to set separate spacing for vertical and horizontal spacing using `horizontal_spacing` and `vertical_spacing` functions.

If you want to maintain old function signature I don't mind changing using different  approach.
* introduce spacing_uniform method with single argument ->  not sure if that's worth it considering that most of the time people will want the uniform spacing 
* keep the  `[f64; 2]`  argument, but multiply one of them by cos(30) -> it may be slightly confusing actual vertical/horizontal spacing differs from argument by than nontrivial multiplier, also having `grid.vertical_spacing(x).horizontal_spacing(y)` different behavior than `grid.spacing([x, y])` can be unexpected
* move the cos(30) multiplication next to the rest of grid calculation, the problem of actual spacing differing from  numbers set is still there, but at least separate methods behave same as array version  