### PR TITLE
Add input handle hook to the `ViewerApp` trait

### DIFF
--- a/crates/vsvg-viewer/src/lib.rs
+++ b/crates/vsvg-viewer/src/lib.rs
@@ -93,6 +93,11 @@ pub trait ViewerApp {
         Ok(())
     }
 
+    /// Handle input
+    ///
+    /// This is call very early in the frame loop to allow consuming input before egui.
+    fn handle_input(&mut self, _ctx: &egui::Context, _document_widget: &mut DocumentWidget) {}
+
     /// Hook to show side panels
     ///
     /// This hook is called before the central panel is drawn, as per the [`egui`] documentation.
@@ -127,9 +132,13 @@ pub trait ViewerApp {
     }
 
     /// Hook to load persistent data.
+    ///
+    /// Use [`eframe::get_value`] to retrieve the data.
     fn load(&mut self, _storage: &dyn eframe::Storage) {}
 
     /// Hook to save persistent data.
+    ///
+    /// Use [`eframe::set_value`] to store the data.
     fn save(&self, _storage: &mut dyn eframe::Storage) {}
 }
 

--- a/crates/vsvg-viewer/src/viewer.rs
+++ b/crates/vsvg-viewer/src/viewer.rs
@@ -151,6 +151,9 @@ impl eframe::App for Viewer {
 
         vsvg::trace_function!();
 
+        // hook to handle input (called early to allow capturing input before egui)
+        self.viewer_app.handle_input(ctx, &mut self.document_widget);
+
         egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
             // The top panel is often a good place for a menu bar:
             egui::menu::bar(ui, |ui| {


### PR DESCRIPTION
This gives a change to implementers to capture input before egui

(doesn't work for tab though, which is always used for menu/ui navigation)