### PR TITLE
Update `CHANGELOG.md` for compatibility with `cargo-dist` and add automation script

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,16 @@
+name: Labels
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require at least one category label
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "common, msvg, vsvg, vsvg-cli, vsvg-viewer, whiskers, web-demo"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "common, msvg, vsvg, vsvg-cli, vsvg-viewer, whiskers, web-demo"
+          labels: "common, msvg, vsvg, vsvg-cli, vsvg-viewer, whiskers, web-demo, release"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
-# Change log
+# 0.2.0 (2023-10-22)
 
-## 0.2.0 (2023-10-22)
-
-### New features
+## New features
 
 * Add support for Catmull-Rom splines by @abey79 in [#36](https://github.com/abey79/vsvg/pull/36)
 * Add some `rng_XXX` convenience functions to `whiskers::Context` and make `rng_range` generic over type by @afternoon2 in [#35](https://github.com/abey79/vsvg/pull/35)
@@ -13,7 +11,7 @@
 * Add in-process profiling with `puffin` and parallelize some layer-level operations by @abey79 in [#44](https://github.com/abey79/vsvg/pull/44)
 * Bump egui to 0.23 and wgpu to 0.17 by @abey79 in [#54](https://github.com/abey79/vsvg/pull/54)
 
-### Performance
+## Performance
 
 * Improve performance of `noise` example by @abey79 in [#45](https://github.com/abey79/vsvg/pull/45)
 * Refactor `vsvg-viewer` to defer all unneeded render data generation by @abey79 in [#49](https://github.com/abey79/vsvg/pull/49)
@@ -21,19 +19,20 @@
 * Add tolerance control and vertex count display to `vsvg-viewer` by @abey79 in [#50](https://github.com/abey79/vsvg/pull/50)
 * Parallelize native CI jobs by @abey79 in [#37](https://github.com/abey79/vsvg/pull/37)
 
-### Fixes
+## Fixes
 
 * Fix README paths linked from main README by @reidab in [#34](https://github.com/abey79/vsvg/pull/34)
 * Rename `whiskers::Runner::with_layout_options` for consistency by @abey79 in [#38](https://github.com/abey79/vsvg/pull/38)
 * Fix spurious colon in `bool` UI widget label by @abey79 in [#40](https://github.com/abey79/vsvg/pull/40)
 
-### New Contributors
+## New Contributors
+
 * @reidab made their first contribution in [#34](https://github.com/abey79/vsvg/pull/34)
 
 **Full Changelog**: https://github.com/abey79/vsvg/compare/v0.1.0...v0.2.0
 
 
-## 0.1.0 (2023-10-01)
+# 0.1.0 (2023-10-01)
 
 * Initial release, including:
   * *vsvg*

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -175,11 +175,11 @@ def main() -> None:
         )
 
     categories = {
-        "whiskers": "`whiskers`",
-        "msvg": "`msvg`",
-        "vsvg-cli": "`vsvg`",
-        "vsvg": "vsvg",
-        "vsvg-viewer": "vsvg",
+        "whiskers": "`whiskers` crates",
+        "msvg": "`msvg` CLI",
+        "vsvg-cli": "`vsvg` CLI",
+        "vsvg": "`vsvg` crate",
+        "vsvg-viewer": "`vsvg-viewer` crate",
         "common": "Common",
         "web-demo": "Web Demos",
         "release": "Release",

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,0 +1,225 @@
+"""
+Summarizes PRs.
+
+Requires the `gh` CLI.
+"""
+from __future__ import annotations
+
+import argparse
+import multiprocessing
+import pathlib
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+import json
+
+from git import Repo  # pip install GitPython
+from tqdm import tqdm
+
+OWNER = "abey79"
+REPO = "vsvg"
+OFFICIAL_DEVS = [
+    "abey79",
+]
+
+
+def eprint(*args, **kwargs) -> None:  # type: ignore
+    print(*args, file=sys.stderr, **kwargs)  # type: ignore
+
+
+@dataclass
+class PrInfo:
+    gh_user_name: str
+    pr_title: str
+    labels: list[str]
+
+
+@dataclass
+class CommitInfo:
+    hexsha: str
+    title: str
+    pr_number: int | None
+
+
+# Slow
+def fetch_pr_info_from_commit_info(commit_info: CommitInfo) -> PrInfo | None:
+    if commit_info.pr_number is None:
+        return None
+    else:
+        return fetch_pr_info(commit_info.pr_number)
+
+
+def run_command(command: list[str]) -> str:
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    output, _ = process.communicate()
+    return_code = process.returncode
+
+    if return_code != 0:
+        raise Exception(
+            f"Command `{' '.join(command)}` failed with return code {return_code}"
+        )
+
+    return output
+
+
+# Slow
+def fetch_pr_info(pr_number: int) -> PrInfo | None:
+    output = run_command(
+        [
+            "gh",
+            "pr",
+            "view",
+            "--repo",
+            f"{OWNER}/{REPO}",
+            f"{pr_number}",
+            "--json",
+            "title,author,labels",
+        ]
+    )
+
+    data = json.loads(output)
+
+    return PrInfo(
+        gh_user_name=data["author"]["login"],
+        pr_title=data["title"],
+        labels=[label["name"] for label in data["labels"]],
+    )
+
+
+def get_commit_info(commit: Any) -> CommitInfo:
+    match = re.match(r"(.*) \(#(\d+)\)", commit.summary)
+    if match:
+        return CommitInfo(
+            hexsha=commit.hexsha,
+            title=str(match.group(1)),
+            pr_number=int(match.group(2)),
+        )
+    else:
+        return CommitInfo(hexsha=commit.hexsha, title=commit.summary, pr_number=None)
+
+
+def print_section(title: str, items: list[str]) -> None:
+    if len(items) > 0:
+        print(f"## {title}")
+        print()
+        for line in items:
+            print(f"- {line}")
+        print()
+
+
+def change_in_changlog(commit_info: CommitInfo, previous_changelog: str) -> bool:
+    hexsha = commit_info.hexsha
+    pr_number = commit_info.pr_number
+
+    if pr_number is None:
+        return f"[{hexsha}]" in previous_changelog
+    else:
+        return f"[#{pr_number}]" in previous_changelog
+
+
+def format_change(commit_info: CommitInfo, pr_info: PrInfo | None) -> str:
+    hexsha = commit_info.hexsha
+    title = commit_info.title
+    pr_number = commit_info.pr_number
+
+    if pr_number is None:
+        summary = (
+            f"{title} [{hexsha}](https://github.com/{OWNER}/{REPO}/commit/{hexsha})"
+        )
+    else:
+        if pr_info is None:
+            eprint(f"Warning: PR #{pr_number} not found")
+
+        title = pr_info.pr_title if pr_info else title
+        title = title.rstrip(".").strip()  # Some PR end with an unnecessary period
+
+        summary = f"{title} [#{pr_number}](https://github.com/{OWNER}/{REPO}/pull/{pr_number})"
+
+        if pr_info is not None:
+            gh_user_name = pr_info.gh_user_name
+            if gh_user_name not in OFFICIAL_DEVS:
+                summary += (
+                    f" (thanks [@{gh_user_name}](https://github.com/{gh_user_name})!)"
+                )
+
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a changelog.")
+    parser.add_argument("--commit-range", help="e.g. 0.11.0..HEAD")
+    args = parser.parse_args()
+
+    # Because how we branch, we sometimes get duplicate commits in the changelog unless we check for it
+    previous_changelog = pathlib.Path("CHANGELOG.md").read_text()
+
+    repo = Repo(".")
+    commits = list(repo.iter_commits(args.commit_range))
+    commits.reverse()  # Most recent last
+    commit_infos = list(map(get_commit_info, commits))
+
+    with multiprocessing.Pool() as pool:
+        pr_infos = list(
+            tqdm(
+                pool.imap(fetch_pr_info_from_commit_info, commit_infos),
+                total=len(commit_infos),
+                desc="Fetch PR info commits",
+            )
+        )
+
+    categories = {
+        "whiskers": "`whiskers`",
+        "msvg": "`msvg`",
+        "vsvg-cli": "`vsvg`",
+        "vsvg": "vsvg",
+        "vsvg-viewer": "vsvg",
+        "common": "Common",
+        "web-demo": "Web Demos",
+        "release": "Release",
+    }
+    by_category = {}
+
+    for commit_info, pr_info in zip(commit_infos, pr_infos):
+        if pr_info is not None:
+            if "exclude-from-changelog" in pr_info.labels:
+                continue
+
+            if "release" in pr_info.labels:
+                continue
+
+        if change_in_changlog(commit_info, previous_changelog):
+            eprint(f"Ignoring dup: {commit_info}")
+            continue
+
+        change = format_change(commit_info, pr_info)
+        labels = pr_info.labels if pr_info else []
+
+        has_category = False
+        for category in categories.keys():
+            if category in labels:
+                by_category.setdefault(category, []).append(change)
+                has_category = True
+                break
+
+        if not has_category:
+            by_category.setdefault("unsorted", []).append(change)
+
+    for category, title in categories.items():
+        print_section(title, by_category.get(category, []))
+
+    print_section("!!! UNSORTED !!!", by_category.get("unsorted", []))
+
+    print(
+        f"**Full Changelog**: https://github.com/{OWNER}/{REPO}/compare/{'...'.join(args.commit_range.split('..'))}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- change formatting of CHANGELOG.md so it's recognised by cargo-dist
- add a script to automate the generation of the changelog, which relies on PR labels (the yellow ones)
- add a GH action to enforce adequate labels on each PR