### PR TITLE
Release 0.3.0

### DIFF
--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -30,12 +30,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: moonrepo/setup-rust@v1
         with:
-          profile: minimal
           target: wasm32-unknown-unknown
-          toolchain: stable
-          override: true
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -34,10 +34,6 @@ jobs:
         with:
           target: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "demo-deploy-"
-
       - uses: taiki-e/install-action@v2
         with:
           tool: just

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: moonrepo/setup-rust@v1
         with:
           profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
@@ -37,11 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: moonrepo/setup-rust@v1
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
@@ -58,11 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: moonrepo/setup-rust@v1
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -55,7 +55,7 @@ jobs:
       - run: just test
 
   docs:
-    runs-on: macos-latest  # workaround for winit failing on linux
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -17,12 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: moonrepo/setup-rust@v1
         with:
-          profile: minimal
           components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: "lint"
 
       - uses: taiki-e/install-action@v2
         with:
@@ -35,13 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: moonrepo/setup-rust@v1
         with:
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: "test"
 
       - uses: taiki-e/install-action@v2
         with:
@@ -56,10 +49,6 @@ jobs:
       - uses: moonrepo/setup-rust@v1
         with:
           components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: "docs-v1"
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/rust-wasm.yml
+++ b/.github/workflows/rust-wasm.yml
@@ -21,10 +21,6 @@ jobs:
           targets: wasm32-unknown-unknown
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "wasm-"
-
       - uses: taiki-e/install-action@v2
         with:
           tool: just

--- a/.github/workflows/rust-wasm.yml
+++ b/.github/workflows/rust-wasm.yml
@@ -16,12 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: moonrepo/setup-rust@v1
         with:
-          profile: minimal
-          target: wasm32-unknown-unknown
-          toolchain: stable
-          override: true
+          targets: wasm32-unknown-unknown
           components: clippy
 
       - uses: Swatinem/rust-cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - First prototype of `msvg` [#68](https://github.com/abey79/vsvg/pull/68)
 - Improve `msvg`'s file list side panel and add file name overlay [#76](https://github.com/abey79/vsvg/pull/76)
+- Fix blank window on first start [#81](https://github.com/abey79/vsvg/pull/81)
 
 ## `vsvg` CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Fit to view on double click [#73](https://github.com/abey79/vsvg/pull/73)
 - Add binary publishing support with `cargo-dist` [#78](https://github.com/abey79/vsvg/pull/78)
 - Update `CHANGELOG.md` for compatibility with `cargo-dist` and add automation script [#79](https://github.com/abey79/vsvg/pull/79)
-- Add plausible.io traffic monitoring to https://whisk.rs [1228521ac97d3286ff2a2f210267a23ee623c969](https://github.com/abey79/vsvg/commit/1228521ac97d3286ff2a2f210267a23ee623c969)
+- Add plausible.io traffic monitoring to https://whisk.rs [`1228521`](https://github.com/abey79/vsvg/commit/1228521ac97d3286ff2a2f210267a23ee623c969)
 - Update to egui 0.24 and wgpu 0.18 [#64](https://github.com/abey79/vsvg/pull/64)
 
 **Full Changelog**: https://github.com/abey79/vsvg/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-# Unreleased
+# 0.3.0 - New `msvg` CLI, better `whiskers`, and more
+
+Released 2023-12-28
+
+## Highlights
+
+- Inspect SVG collections with the new, blazing fast `msvg` CLI (early alpha stage).
+- `whiskers` improvements:
+  - New hexagonal grid helper.
+  - Support for nested `struct` in sketch param.
 
 ## `whiskers` crates
 
@@ -36,7 +45,9 @@
 **Full Changelog**: https://github.com/abey79/vsvg/compare/v0.2.0...v0.3.0
 
 
-# 0.2.0 (2023-10-22)
+# 0.2.0
+
+Released 2023-10-22
 
 ## New features
 
@@ -70,7 +81,9 @@
 **Full Changelog**: https://github.com/abey79/vsvg/compare/v0.1.0...v0.2.0
 
 
-# 0.1.0 (2023-10-01)
+# 0.1.0
+
+Released 2023-10-01
 
 * Initial release, including:
   * *vsvg*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+# Unreleased
+
+## `whiskers` crates
+
+- Add support for custom `struct` as sketch parameter [#66](https://github.com/abey79/vsvg/pull/66)
+- Add hexagonal grid helper [#60](https://github.com/abey79/vsvg/pull/60) (thanks [@afternoon2](https://github.com/afternoon2)!)
+- Change `HexGrid::spacing()` to accept a single scalar and maintain hexagonal grid [#72](https://github.com/abey79/vsvg/pull/72) (thanks [@karliss](https://github.com/karliss)!)
+- Implement `step` UI parameter for numeric value in normal mode [#58](https://github.com/abey79/vsvg/pull/58)
+
+## `msvg` CLI
+
+- First prototype of `msvg` [#68](https://github.com/abey79/vsvg/pull/68)
+- Improve `msvg`'s file list side panel and add file name overlay [#76](https://github.com/abey79/vsvg/pull/76)
+
+## `vsvg` CLI
+
+- Add "merge layers" operation to `vsvg` and `vsvg-cli` [#61](https://github.com/abey79/vsvg/pull/61)
+- Add `--strokewidth <W>` command to override the stroke width of all paths [#62](https://github.com/abey79/vsvg/pull/62)
+- Add `--flatten <TOL>` command to flatten all curves with the provided tolerance [#63](https://github.com/abey79/vsvg/pull/63)
+
+## `vsvg-viewer` crate
+
+- Improve `ViewerApp` hooks to give implementers more flexibility [#71](https://github.com/abey79/vsvg/pull/71)
+- Add input handle hook to the `ViewerApp` trait [#74](https://github.com/abey79/vsvg/pull/74)
+- Add `ListItem` UI widget [#75](https://github.com/abey79/vsvg/pull/75)
+
+## Common
+
+- Fit to view on double click [#73](https://github.com/abey79/vsvg/pull/73)
+- Add binary publishing support with `cargo-dist` [#78](https://github.com/abey79/vsvg/pull/78)
+- Update `CHANGELOG.md` for compatibility with `cargo-dist` and add automation script [#79](https://github.com/abey79/vsvg/pull/79)
+- Add plausible.io traffic monitoring to https://whisk.rs [1228521ac97d3286ff2a2f210267a23ee623c969](https://github.com/abey79/vsvg/commit/1228521ac97d3286ff2a2f210267a23ee623c969)
+- Update to egui 0.24 and wgpu 0.18 [#64](https://github.com/abey79/vsvg/pull/64)
+
+**Full Changelog**: https://github.com/abey79/vsvg/compare/v0.2.0...v0.3.0
+
+
 # 0.2.0 (2023-10-22)
 
 ## New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "msvg"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "anyhow",
  "camino",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-cli"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "clap",
  "dhat",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-viewer"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-derive"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-web-demo"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "itertools 0.12.0",
  "whiskers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "msvg"
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 dependencies = [
  "anyhow",
  "camino",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg"
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-cli"
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 dependencies = [
  "clap",
  "dhat",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-viewer"
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers"
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-derive"
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-web-demo"
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 dependencies = [
  "itertools 0.12.0",
  "whiskers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "msvg"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "camino",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-cli"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "clap",
  "dhat",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-viewer"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-derive"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-web-demo"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "itertools 0.12.0",
  "whiskers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "msvg"
-version = "0.3.0-rc.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "camino",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg"
-version = "0.3.0-rc.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-cli"
-version = "0.3.0-rc.3"
+version = "0.3.0"
 dependencies = [
  "clap",
  "dhat",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-viewer"
-version = "0.3.0-rc.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers"
-version = "0.3.0-rc.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-derive"
-version = "0.3.0-rc.3"
+version = "0.3.0"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-web-demo"
-version = "0.3.0-rc.3"
+version = "0.3.0"
 dependencies = [
  "itertools 0.12.0",
  "whiskers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "msvg"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "anyhow",
  "camino",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-cli"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "clap",
  "dhat",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-viewer"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-derive"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-web-demo"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "itertools 0.12.0",
  "whiskers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "msvg"
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 dependencies = [
  "anyhow",
  "camino",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg"
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-cli"
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 dependencies = [
  "clap",
  "dhat",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "vsvg-viewer"
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers"
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-derive"
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "whiskers-web-demo"
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 dependencies = [
  "itertools 0.12.0",
  "whiskers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,12 @@ ci = ["github"]
 # The installers to generate for each app
 installers = ["shell", "powershell", "msi"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
+
+[workspace.metadata.dist.github-custom-runners]
+aarch64-unknown-linux-gnu = "buildjet-8vcpu-ubuntu-2204-arm"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ resolver = "2"
 [workspace.dependencies]
 # When using alpha-release, always use exact version, e.g. `version = "=0.x.y-alpha.z"
 # This is because we treat alpha-releases as incompatible, but semver doesn't.
-vsvg = { path = "crates/vsvg", version = "=0.3.0-rc.3" }
-vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0-rc.3" }
-whiskers = { path = "crates/whiskers", version = "=0.3.0-rc.3" }
-whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0-rc.3" }
+vsvg = { path = "crates/vsvg", version = "=0.3.0" }
+vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0" }
+whiskers = { path = "crates/whiskers", version = "=0.3.0" }
+whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0" }
 
 # dependencies
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ resolver = "2"
 [workspace.dependencies]
 # When using alpha-release, always use exact version, e.g. `version = "=0.x.y-alpha.z"
 # This is because we treat alpha-releases as incompatible, but semver doesn't.
-vsvg = { path = "crates/vsvg", version = "=0.3.0-rc.0" }
-vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0-rc.0" }
-whiskers = { path = "crates/whiskers", version = "=0.3.0-rc.0" }
-whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0-rc.0" }
+vsvg = { path = "crates/vsvg", version = "=0.3.0-rc.1" }
+vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0-rc.1" }
+whiskers = { path = "crates/whiskers", version = "=0.3.0-rc.1" }
+whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0-rc.1" }
 
 # dependencies
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ resolver = "2"
 [workspace.dependencies]
 # When using alpha-release, always use exact version, e.g. `version = "=0.x.y-alpha.z"
 # This is because we treat alpha-releases as incompatible, but semver doesn't.
-vsvg = { path = "crates/vsvg", version = "=0.3.0-alpha.0" }
-vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0-alpha.0" }
-whiskers = { path = "crates/whiskers", version = "=0.3.0-alpha.0" }
-whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0-alpha.0" }
+vsvg = { path = "crates/vsvg", version = "=0.3.0-rc.0" }
+vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0-rc.0" }
+whiskers = { path = "crates/whiskers", version = "=0.3.0-rc.0" }
+whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0-rc.0" }
 
 # dependencies
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ eframe = { version = "0.24.1", default-features = false, features = [
     "default_fonts",
     "persistence",
     "wgpu",
+    "wayland",
+    "x11",
 ] }
 egui = "0.24.1"
 getrandom = { version = "0.2", features = ["js"] } # wasm support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ resolver = "2"
 [workspace.dependencies]
 # When using alpha-release, always use exact version, e.g. `version = "=0.x.y-alpha.z"
 # This is because we treat alpha-releases as incompatible, but semver doesn't.
-vsvg = { path = "crates/vsvg", version = "=0.3.0" }
-vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0" }
-whiskers = { path = "crates/whiskers", version = "=0.3.0" }
-whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0" }
+vsvg = { path = "crates/vsvg", version = "=0.4.0-alpha.0" }
+vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.4.0-alpha.0" }
+whiskers = { path = "crates/whiskers", version = "=0.4.0-alpha.0" }
+whiskers-derive = { path = "crates/whiskers-derive", version = "=0.4.0-alpha.0" }
 
 # dependencies
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ resolver = "2"
 [workspace.dependencies]
 # When using alpha-release, always use exact version, e.g. `version = "=0.x.y-alpha.z"
 # This is because we treat alpha-releases as incompatible, but semver doesn't.
-vsvg = { path = "crates/vsvg", version = "=0.3.0-rc.1" }
-vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0-rc.1" }
-whiskers = { path = "crates/whiskers", version = "=0.3.0-rc.1" }
-whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0-rc.1" }
+vsvg = { path = "crates/vsvg", version = "=0.3.0-rc.2" }
+vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0-rc.2" }
+whiskers = { path = "crates/whiskers", version = "=0.3.0-rc.2" }
+whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0-rc.2" }
 
 # dependencies
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ resolver = "2"
 [workspace.dependencies]
 # When using alpha-release, always use exact version, e.g. `version = "=0.x.y-alpha.z"
 # This is because we treat alpha-releases as incompatible, but semver doesn't.
-vsvg = { path = "crates/vsvg", version = "=0.3.0-rc.2" }
-vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0-rc.2" }
-whiskers = { path = "crates/whiskers", version = "=0.3.0-rc.2" }
-whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0-rc.2" }
+vsvg = { path = "crates/vsvg", version = "=0.3.0-rc.3" }
+vsvg-viewer = { path = "crates/vsvg-viewer", version = "=0.3.0-rc.3" }
+whiskers = { path = "crates/whiskers", version = "=0.3.0-rc.3" }
+whiskers-derive = { path = "crates/whiskers-derive", version = "=0.3.0-rc.3" }
 
 # dependencies
 anyhow = "1"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,10 @@
 # Release process
 
 - Create branch `release/0.x.y` and related PR, use "release" label
-- Update `CHANGELOG.md`, use "Unreleased" heading unless final release
+- Update `CHANGELOG.md`, use "Unreleased" heading unless final release, copy-paste-edit from:
+  ```
+  python scripts/changelog --commit-range v0.X-1.Y-1..HEAD
+  ```
 - Bump version to `-rc.Z`:
   ```
   cargo ws version -a --exact --force "*" --no-git-commit

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+# Release process
+
+- Create branch `release/0.x.y` and related PR, use "release" label
+- Update `CHANGELOG.md`, use "Unreleased" heading unless final release
+- Bump version to `-rc.Z`:
+  ```
+  cargo ws version -a --exact --force "*" --no-git-commit
+  ```
+- Check, commit, push, and ensure CI ✅
+- Publish to <https://crates.io>
+  ```
+  cargo ws publish --from-git
+  ```
+- Check docs.rs ✅
+  - <https://docs.rs/whiskers/>
+  - <https://docs.rs/vsvg/>
+  - <https://docs.rs/vsvg-viewer/>
+- Tag `v0.X.Y` and push tag
+- Check GH Release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,5 +18,8 @@
   - <https://docs.rs/whiskers/>
   - <https://docs.rs/vsvg/>
   - <https://docs.rs/vsvg-viewer/>
+- Finalise `CHANGELOG.md` with proper heading
 - Tag `v0.X.Y` and push tag
 - Check GH Release
+- Bump version to next alpha
+- Squash-merge the release PR, undelete the branch

--- a/crates/msvg/Cargo.toml
+++ b/crates/msvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "msvg"
 description = "Fast SVG browser for pen-plotter users"
 authors = ["Antoine Beyeler"]
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/msvg/Cargo.toml
+++ b/crates/msvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "msvg"
 description = "Fast SVG browser for pen-plotter users"
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/msvg/Cargo.toml
+++ b/crates/msvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "msvg"
 description = "Fast SVG browser for pen-plotter users"
 authors = ["Antoine Beyeler"]
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/msvg/Cargo.toml
+++ b/crates/msvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "msvg"
 description = "Fast SVG browser for pen-plotter users"
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/msvg/Cargo.toml
+++ b/crates/msvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "msvg"
 description = "Fast SVG browser for pen-plotter users"
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/msvg/Cargo.toml
+++ b/crates/msvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "msvg"
 description = "Fast SVG browser for pen-plotter users"
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.3"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/msvg/README.md
+++ b/crates/msvg/README.md
@@ -2,17 +2,23 @@
 
 This crate is part of the [*vsvg* project](https://github.com/abey79/vsvg).
 
-**Status**: prototyping stage, aiming toward MVP.
+**Status**: functional but very beta.
 
 ## What's this?
 
-Compared to *vpype*, *vsvg* is *extremely* fast to load and display SVGs. This makes a tool that can load a whole bunch of SVGs possible, for example to chose amongst many realisations of a generative art algorithm. This is what *msvg* aims to be.
+Compared to *vpype*, *vsvg* is *extremely* fast to load and display SVGs. This makes a tool that can load a _whole bunch_ of SVGs possible, for example to chose amongst many realisations of a generative art algorithm. This is what *msvg* aims to be.
 
 https://github.com/abey79/vsvg/assets/49431240/817f7dbe-2562-4c4d-9ab2-41368ed60677
 
 ## Installation
 
-**WARNING**: this is at an early prototype stage!
+
+### From pre-built binaries
+
+A number of pre-built binaries and installers are available on the [Release](https://github.com/abey79/vsvg/releases/latest) page, including shell/PowerShell-based installers, binary archives for most platforms, and MSI archives for Windows.
+
+
+### From source
 
 To install `msvg`, you'll need Rust, which you can install using [`rustup`](https://www.rust-lang.org/learn/get-started).
 
@@ -29,4 +35,4 @@ cargo install --git https://github.com/abey79/vsvg msvg
 msvg PATH [PATH...]
 ```
 
-`PATH` may be a SVG file or a directory. If it is a directory, it will be recursively traversed and all founds will be included.
+`PATH` may be an SVG file or a directory. If it is a directory, it will be recursively traversed and all founds will be included.

--- a/crates/msvg/README.md
+++ b/crates/msvg/README.md
@@ -25,7 +25,13 @@ To install `msvg`, you'll need Rust, which you can install using [`rustup`](http
 Then, run the following command:
 
 ```
-cargo install --git https://github.com/abey79/vsvg msvg
+cargo install msvg
+```
+
+To uninstall `msvg`:
+
+```
+cargo uninstall msvg
 ```
 
 

--- a/crates/msvg/src/app.rs
+++ b/crates/msvg/src/app.rs
@@ -26,9 +26,17 @@ enum LoadedDocument {
     // TODO: Document::from_svg() should return an proper error type
 }
 
-#[derive(Default, serde::Deserialize, serde::Serialize)]
+#[derive(serde::Deserialize, serde::Serialize)]
 struct AppState {
     side_panel_open: bool,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            side_panel_open: true,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -283,15 +291,6 @@ impl ViewerApp for App {
                     self.scroll_to_selected_row = false;
                 }
             }
-
-            if self.document_dirty {
-                if let Some(LoadedDocument::Loaded(document)) =
-                    self.loaded_documents.get(&self.paths[self.active_document])
-                {
-                    document_widget.set_document(document.clone());
-                    self.document_dirty = false;
-                }
-            }
         };
 
         // --- Side panel structure ---
@@ -327,6 +326,17 @@ impl ViewerApp for App {
                     });
                 });
             });
+
+        // --- Update the document widget if needed ---
+
+        if self.document_dirty {
+            if let Some(LoadedDocument::Loaded(document)) =
+                self.loaded_documents.get(&self.paths[self.active_document])
+            {
+                document_widget.set_document(document.clone());
+                self.document_dirty = false;
+            }
+        }
 
         Ok(())
     }

--- a/crates/vsvg-cli/Cargo.toml
+++ b/crates/vsvg-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-cli"
 description = "An experimental CLI SVG manipulation and viewer tool for plotter users."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-cli/Cargo.toml
+++ b/crates/vsvg-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-cli"
 description = "An experimental CLI SVG manipulation and viewer tool for plotter users."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-cli/Cargo.toml
+++ b/crates/vsvg-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-cli"
 description = "An experimental CLI SVG manipulation and viewer tool for plotter users."
 authors = ["Antoine Beyeler"]
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-cli/Cargo.toml
+++ b/crates/vsvg-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-cli"
 description = "An experimental CLI SVG manipulation and viewer tool for plotter users."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-cli/Cargo.toml
+++ b/crates/vsvg-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-cli"
 description = "An experimental CLI SVG manipulation and viewer tool for plotter users."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.3"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-cli/Cargo.toml
+++ b/crates/vsvg-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-cli"
 description = "An experimental CLI SVG manipulation and viewer tool for plotter users."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-cli/README.md
+++ b/crates/vsvg-cli/README.md
@@ -18,14 +18,16 @@ A number of pre-built binaries and installers are available on the [Release](htt
 
 ### From source
 
+To install the `vsvg` CLI, you'll need Rust, which you can install using [`rustup`](https://www.rust-lang.org/learn/get-started).
+
+Then, run the following command:
+
+```
+cargo install vsvg-cli
+```
+
 Build and install *vsvg-cli*:
 
-```
-cargo build --release
-cargo install --path vsvg-cli
-```
-
-(If you cannot run `cargo`, your path hasn't been set correctly when installing Rust. Restart your terminal and try again. If it still fails, add `$HOME/.cargo/bin` in your PATH.)
 
 The `vsvg` command should now be available:
 
@@ -33,7 +35,7 @@ The `vsvg` command should now be available:
 vsvg --help
 ```
 
-To uninstall the `vsvg` command:
+To uninstall the `vsvg` CLI:
 
 ```
 cargo uninstall vsvg-cli

--- a/crates/vsvg-cli/README.md
+++ b/crates/vsvg-cli/README.md
@@ -11,6 +11,13 @@ This crate is part of the [*vsvg* project](https://github.com/abey79/vsvg).
 
 ## Installation
 
+### From pre-built binaries
+
+A number of pre-built binaries and installers are available on the [Release](https://github.com/abey79/vsvg/releases/latest) page, including shell/PowerShell-based installers, binary archives for most platforms, and MSI archives for Windows.
+
+
+### From source
+
 Build and install *vsvg-cli*:
 
 ```

--- a/crates/vsvg-viewer/Cargo.toml
+++ b/crates/vsvg-viewer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-viewer"
 description = "Portable, hardware-accelerated, extensible viewer for the vsvg crate."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-viewer/Cargo.toml
+++ b/crates/vsvg-viewer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-viewer"
 description = "Portable, hardware-accelerated, extensible viewer for the vsvg crate."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-viewer/Cargo.toml
+++ b/crates/vsvg-viewer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-viewer"
 description = "Portable, hardware-accelerated, extensible viewer for the vsvg crate."
 authors = ["Antoine Beyeler"]
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-viewer/Cargo.toml
+++ b/crates/vsvg-viewer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-viewer"
 description = "Portable, hardware-accelerated, extensible viewer for the vsvg crate."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-viewer/Cargo.toml
+++ b/crates/vsvg-viewer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-viewer"
 description = "Portable, hardware-accelerated, extensible viewer for the vsvg crate."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.3"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg-viewer/Cargo.toml
+++ b/crates/vsvg-viewer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg-viewer"
 description = "Portable, hardware-accelerated, extensible viewer for the vsvg crate."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg/Cargo.toml
+++ b/crates/vsvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg"
 description = "Core library for pen-plotter graphics."
 authors = ["Antoine Beyeler"]
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg/Cargo.toml
+++ b/crates/vsvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg"
 description = "Core library for pen-plotter graphics."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg/Cargo.toml
+++ b/crates/vsvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg"
 description = "Core library for pen-plotter graphics."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.3"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg/Cargo.toml
+++ b/crates/vsvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg"
 description = "Core library for pen-plotter graphics."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg/Cargo.toml
+++ b/crates/vsvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg"
 description = "Core library for pen-plotter graphics."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/vsvg/Cargo.toml
+++ b/crates/vsvg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vsvg"
 description = "Core library for pen-plotter graphics."
 authors = ["Antoine Beyeler"]
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers-derive/Cargo.toml
+++ b/crates/whiskers-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-derive"
 description = "Procedural macro crate for whiskers."
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers-derive/Cargo.toml
+++ b/crates/whiskers-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-derive"
 description = "Procedural macro crate for whiskers."
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers-derive/Cargo.toml
+++ b/crates/whiskers-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-derive"
 description = "Procedural macro crate for whiskers."
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers-derive/Cargo.toml
+++ b/crates/whiskers-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-derive"
 description = "Procedural macro crate for whiskers."
-version = "0.3.0-rc.3"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers-derive/Cargo.toml
+++ b/crates/whiskers-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-derive"
 description = "Procedural macro crate for whiskers."
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers-derive/Cargo.toml
+++ b/crates/whiskers-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-derive"
 description = "Procedural macro crate for whiskers."
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers-web-demo/Cargo.toml
+++ b/crates/whiskers-web-demo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-web-demo"
 description = "Official demo sketch for whiskers."
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 edition = "2021"
 readme = "README.md"
 homepage = "https//bylr.info/vsvg/"

--- a/crates/whiskers-web-demo/Cargo.toml
+++ b/crates/whiskers-web-demo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-web-demo"
 description = "Official demo sketch for whiskers."
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https//bylr.info/vsvg/"

--- a/crates/whiskers-web-demo/Cargo.toml
+++ b/crates/whiskers-web-demo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-web-demo"
 description = "Official demo sketch for whiskers."
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https//bylr.info/vsvg/"

--- a/crates/whiskers-web-demo/Cargo.toml
+++ b/crates/whiskers-web-demo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-web-demo"
 description = "Official demo sketch for whiskers."
-version = "0.3.0-rc.3"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https//bylr.info/vsvg/"

--- a/crates/whiskers-web-demo/Cargo.toml
+++ b/crates/whiskers-web-demo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-web-demo"
 description = "Official demo sketch for whiskers."
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 readme = "README.md"
 homepage = "https//bylr.info/vsvg/"

--- a/crates/whiskers-web-demo/Cargo.toml
+++ b/crates/whiskers-web-demo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whiskers-web-demo"
 description = "Official demo sketch for whiskers."
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 readme = "README.md"
 homepage = "https//bylr.info/vsvg/"

--- a/crates/whiskers/Cargo.toml
+++ b/crates/whiskers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "whiskers"
 authors = ["Antoine Beyeler"]
 description = "Processing-like, interactive sketching environment for plotter generative art."
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers/Cargo.toml
+++ b/crates/whiskers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "whiskers"
 authors = ["Antoine Beyeler"]
 description = "Processing-like, interactive sketching environment for plotter generative art."
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers/Cargo.toml
+++ b/crates/whiskers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "whiskers"
 authors = ["Antoine Beyeler"]
 description = "Processing-like, interactive sketching environment for plotter generative art."
-version = "0.3.0-rc.3"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers/Cargo.toml
+++ b/crates/whiskers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "whiskers"
 authors = ["Antoine Beyeler"]
 description = "Processing-like, interactive sketching environment for plotter generative art."
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers/Cargo.toml
+++ b/crates/whiskers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "whiskers"
 authors = ["Antoine Beyeler"]
 description = "Processing-like, interactive sketching environment for plotter generative art."
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/crates/whiskers/Cargo.toml
+++ b/crates/whiskers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "whiskers"
 authors = ["Antoine Beyeler"]
 description = "Processing-like, interactive sketching environment for plotter generative art."
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/abey79/vsvg"

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -119,7 +119,7 @@ def change_in_changlog(commit_info: CommitInfo, previous_changelog: str) -> bool
     pr_number = commit_info.pr_number
 
     if pr_number is None:
-        return f"[{hexsha}]" in previous_changelog
+        return f"/{hexsha})" in previous_changelog
     else:
         return f"[#{pr_number}]" in previous_changelog
 
@@ -130,9 +130,7 @@ def format_change(commit_info: CommitInfo, pr_info: PrInfo | None) -> str:
     pr_number = commit_info.pr_number
 
     if pr_number is None:
-        summary = (
-            f"{title} [{hexsha}](https://github.com/{OWNER}/{REPO}/commit/{hexsha})"
-        )
+        summary = f"{title} [`{hexsha[:7]}`](https://github.com/{OWNER}/{REPO}/commit/{hexsha})"
     else:
         if pr_info is None:
             eprint(f"Warning: PR #{pr_number} not found")


### PR DESCRIPTION
- add `x11` and `wayland` features to `eframe` (should fix docs.rs build error)
- add `RELEASE.md`
- updated installation instruction in `README.md` for `msvg` and `vsvg-cli`
- add support for aarch64 linux
- fix CI to honour rust-toolchain.toml