### PR TITLE
Impove `Unit` and introduce `Length`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
@@ -4113,6 +4113,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lyon_geom",
+ "num-traits",
  "puffin",
  "quick-xml",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ getrandom = { version = "0.2", features = ["js"] } # wasm support
 itertools = "0.12.0"
 kurbo = "0.10.3"
 log = "0.4.20"
+num-traits = "0.2.17"
 puffin = "0.18.0"  # sync with egui
 puffin_egui = "0.24.0"  # sync with egui
 rand = "0.8.5"

--- a/crates/vsvg/Cargo.toml
+++ b/crates/vsvg/Cargo.toml
@@ -21,6 +21,7 @@ kurbo.workspace = true
 lazy_static = "1.4.0"
 log.workspace = true
 lyon_geom = "1.0.4"
+num-traits.workspace = true
 puffin = { workspace = true, optional = true }
 quick-xml = "0.30.0"
 rayon.workspace = true

--- a/crates/vsvg/src/length.rs
+++ b/crates/vsvg/src/length.rs
@@ -1,0 +1,250 @@
+use crate::Unit;
+use num_traits::{AsPrimitive, Float};
+use std::fmt::{Display, Formatter};
+
+/// A physical length, described by a value and a [`Unit`].
+///
+/// A [`Length`] can be created with [`Length::new`] or by multiplying a float with a [`Unit`]:
+/// ```
+/// # use vsvg::{Unit, Length};
+/// assert_eq!(Length::new(0.0356, Unit::Cm), 0.0356 * Unit::Cm);
+/// ```
+///
+/// All float conversion assume the default [`Unit`] of [`Unit::Px`]:
+/// ```
+/// # use vsvg::{Unit, Length};
+/// assert_eq!(Length::from(96.0), Length::new(96., Unit::Px));
+/// assert_eq!(f64::from(1.0 * Unit::In), 96.0);
+/// ```
+///
+/// The usual arithmetic operations are supported.
+///
+/// **Note**: Floats are always considered as [`Unit::Px`]. When adding or subtracting two
+/// [`Length`]s, the result will have the [`Unit`] of the left-hand side.
+///
+/// ```
+/// # use vsvg::{Unit, Length};
+/// // Negation is supported.
+/// assert_eq!(-Length::new(1.0, Unit::In), -1.0 * Unit::In);
+///
+/// // The result has the unit of the left-hand side.
+/// assert_eq!(1.0 * Unit::In + 2.54 * Unit::Cm, 2.0 * Unit::In);
+/// assert_eq!(5.08 * Unit::Cm - 1.0 * Unit::In, 2.54 * Unit::Cm);
+///
+/// // Floats are considered pixels.
+/// assert_eq!(1.0 * Unit::In + 96.0, 2.0 * Unit::In);
+/// assert_eq!(96.0 + 1.0 * Unit::In , 2.0 * Unit::In);
+/// assert_eq!(2.0 * Unit::In - 96.0, 1.0 * Unit::In);
+/// assert_eq!(96.0 - 0.5 * Unit::In, 0.5 * Unit::In);
+///
+/// // Multiplication and division by floats is supported.
+/// // Note: dividing by a `Length` is not supported.
+/// assert_eq!((1.0 * Unit::In) * 2.0, 2.0 * Unit::In);
+/// assert_eq!(2.0 * (1.0 * Unit::In), 2.0 * Unit::In);
+/// assert_eq!((1.0 * Unit::In) / 2.0, 0.5 * Unit::In);
+/// ```
+///
+/// [`Length`] implements [`From`] for [`Unit`], so you can use [`Unit`] as a shorthand:
+/// ```
+/// # use vsvg::{Unit, Length};
+/// assert_eq!(Length::from(Unit::In), Length::new(1., Unit::In));
+/// ```
+///
+/// A [`Length`] with a different [`Unit`] can be converted using [`Length::convert_to`]:
+/// ```
+/// # use vsvg::{Unit, Length};
+/// let l = Length::new(2.54, Unit::Cm);
+/// assert_eq!(l.convert_to(Unit::In), 1.0 * Unit::In);
+/// ```
+///
+/// [`Length`] delegates [`Display`] to [`f64`], so it supports the standard float formatting
+/// syntax:
+/// ```
+/// # use vsvg::Length;
+/// let l = Length::new(0.0356, vsvg::Unit::Cm);
+/// assert_eq!(format!("{l:.2}"), "0.04cm");
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Length {
+    pub value: f64,
+    pub unit: Unit,
+}
+
+impl Default for Length {
+    fn default() -> Self {
+        Length {
+            value: 0.0,
+            unit: Unit::Px,
+        }
+    }
+}
+
+impl Display for Length {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.value.fmt(f)?;
+        write!(f, "{}", self.unit)
+    }
+}
+
+impl Length {
+    #[must_use]
+    pub fn new<F: Float + AsPrimitive<f64>>(value: F, unit: Unit) -> Self {
+        Self {
+            value: value.as_(),
+            unit,
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
+    pub fn to_px<F: Float>(&self) -> F {
+        F::from(self.value).unwrap() * self.unit.to_px::<F>()
+    }
+
+    #[must_use]
+    pub fn convert_to(self, unit: Unit) -> Self {
+        Self {
+            value: self.unit.convert_to(&unit, self.value),
+            unit,
+        }
+    }
+}
+
+impl From<Unit> for Length {
+    fn from(value: Unit) -> Self {
+        Self::new(1.0f64, value)
+    }
+}
+
+impl From<&'_ Unit> for Length {
+    fn from(value: &'_ Unit) -> Self {
+        Self::new(1.0f64, *value)
+    }
+}
+
+impl<F: Float + AsPrimitive<f64>> From<F> for Length {
+    fn from(value: F) -> Self {
+        Self::new(value, Unit::Px)
+    }
+}
+
+impl std::ops::Add<Length> for Length {
+    type Output = Self;
+
+    fn add(self, rhs: Length) -> Self::Output {
+        Self {
+            value: self.value + rhs.convert_to(self.unit).value,
+            unit: self.unit,
+        }
+    }
+}
+
+impl std::ops::Sub<Length> for Length {
+    type Output = Self;
+
+    fn sub(self, rhs: Length) -> Self::Output {
+        Self {
+            value: self.value - rhs.convert_to(self.unit).value,
+            unit: self.unit,
+        }
+    }
+}
+
+impl std::ops::Neg for Length {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self {
+            value: -self.value,
+            unit: self.unit,
+        }
+    }
+}
+
+impl<F: Float + AsPrimitive<f64>> std::ops::Add<F> for Length {
+    type Output = Self;
+
+    fn add(self, rhs: F) -> Self::Output {
+        Self {
+            value: self.value + Unit::Px.convert_to(&self.unit, rhs.as_()),
+            unit: self.unit,
+        }
+    }
+}
+
+impl<F: Float + AsPrimitive<f64>> std::ops::Sub<F> for Length {
+    type Output = Self;
+
+    fn sub(self, rhs: F) -> Self::Output {
+        Self {
+            value: self.value - Unit::Px.convert_to(&self.unit, rhs.as_()),
+            unit: self.unit,
+        }
+    }
+}
+
+impl<F: Float + AsPrimitive<f64>> std::ops::Mul<F> for Length {
+    type Output = Length;
+
+    fn mul(self, rhs: F) -> Self::Output {
+        Self {
+            value: self.value * rhs.as_(),
+            unit: self.unit,
+        }
+    }
+}
+
+impl<F: Float + AsPrimitive<f64>> std::ops::Div<F> for Length {
+    type Output = Length;
+
+    fn div(self, rhs: F) -> Self::Output {
+        Self {
+            value: self.value / rhs.as_(),
+            unit: self.unit,
+        }
+    }
+}
+
+// Orphan rule requires us to unroll these.
+macro_rules! length_trait_impl {
+    ($t:ty) => {
+        impl From<Length> for $t {
+            fn from(length: Length) -> Self {
+                length.to_px()
+            }
+        }
+
+        impl From<&'_ Length> for $t {
+            fn from(length: &'_ Length) -> Self {
+                length.to_px()
+            }
+        }
+
+        impl std::ops::Add<Length> for $t {
+            type Output = Length;
+
+            fn add(self, rhs: Length) -> Self::Output {
+                rhs.add(self)
+            }
+        }
+
+        impl std::ops::Sub<Length> for $t {
+            type Output = Length;
+
+            fn sub(self, rhs: Length) -> Self::Output {
+                -rhs.sub(self)
+            }
+        }
+
+        impl std::ops::Mul<Length> for $t {
+            type Output = Length;
+
+            fn mul(self, rhs: Length) -> Self::Output {
+                rhs.mul(self)
+            }
+        }
+    };
+}
+
+length_trait_impl!(f32);
+length_trait_impl!(f64);

--- a/crates/vsvg/src/lib.rs
+++ b/crates/vsvg/src/lib.rs
@@ -11,6 +11,7 @@ mod color;
 mod crop;
 mod document;
 mod layer;
+mod length;
 mod optimization;
 mod page_size;
 mod path;
@@ -28,6 +29,7 @@ pub use catmull_rom::*;
 pub use crop::*;
 pub use document::*;
 pub use layer::*;
+pub use length::*;
 #[allow(unused_imports)]
 pub use optimization::*;
 pub use page_size::*;

--- a/crates/vsvg/src/page_size.rs
+++ b/crates/vsvg/src/page_size.rs
@@ -184,7 +184,7 @@ impl PageSize {
             Self::ExecutiveH => (Self::EXECUTIVE_SIZE.1, Self::EXECUTIVE_SIZE.0),
             Self::TabloidH => (Self::TABLOID_SIZE.1, Self::TABLOID_SIZE.0),
 
-            Self::Custom(w, h, unit) => (*w * unit.to_px(), *h * unit.to_px()),
+            Self::Custom(w, h, unit) => ((*w * unit).into(), (*h * unit).into()),
         }
     }
 

--- a/crates/vsvg/src/unit.rs
+++ b/crates/vsvg/src/unit.rs
@@ -1,6 +1,15 @@
-use crate::Length;
-use num_traits::{AsPrimitive, Float};
 use std::fmt::{Display, Formatter};
+
+use num_traits::{AsPrimitive, Float};
+
+use crate::Length;
+
+/// Errors related to [`Unit`]
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum UnitError {
+    #[error("Unrecognised unit '{0}'")]
+    UnrecognisedError(String),
+}
 
 /// A distance unit.
 ///
@@ -46,6 +55,7 @@ pub enum Unit {
     Pt,
 }
 
+/// List of all available units, useful for iteration.
 pub const UNITS: [Unit; 11] = [
     Unit::Px,
     Unit::In,
@@ -61,6 +71,7 @@ pub const UNITS: [Unit; 11] = [
 ];
 
 impl Unit {
+    /// Convert the unit into the corresponding pixel factor.
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn to_px<F: Float>(&self) -> F {
@@ -79,18 +90,30 @@ impl Unit {
         }
     }
 
+    /// Convert a value from pixel unit.
+    #[must_use]
+    #[inline]
+    pub fn convert<F: Float>(&self, pixel_value: F) -> F {
+        self.convert_from(&Unit::Px, pixel_value)
+    }
+
+    /// Convert a value from `from_unit` to this [`Unit`].
     #[must_use]
     #[inline]
     pub fn convert_from<F: Float>(&self, from_unit: &Unit, value: F) -> F {
         value * from_unit.to_px() / self.to_px()
     }
 
+    /// Convert a value from this [`Unit`] to `to_unit`.
     #[must_use]
     #[inline]
     pub fn convert_to<F: Float>(&self, to_unit: &Unit, value: F) -> F {
         value * self.to_px() / to_unit.to_px()
     }
 
+    /// Convert the unit to its string representation.
+    ///
+    /// Note: The opposite operation is available via the [`TryFrom`] trait.
     #[must_use]
     pub const fn to_str(&self) -> &'static str {
         match &self {
@@ -107,12 +130,6 @@ impl Unit {
             Self::Pt => "pt",
         }
     }
-}
-
-#[derive(thiserror::Error, Debug, PartialEq)]
-pub enum UnitError {
-    #[error("Unrecognised unit '{0}'")]
-    UnrecognisedError(String),
 }
 
 impl TryFrom<&str> for Unit {

--- a/crates/vsvg/src/unit.rs
+++ b/crates/vsvg/src/unit.rs
@@ -1,7 +1,36 @@
-/// A length unit
+use crate::Length;
+use num_traits::{AsPrimitive, Float};
+use std::fmt::{Display, Formatter};
+
+/// A distance unit.
 ///
-/// Doc TODO:
-/// - Mul
+/// Combined with [`Length`], can be used to manipulate physical length and convert between units.
+/// Conversion from/to strings is also supported.
+///
+/// Convert between units:
+/// ```
+/// # use vsvg::{Unit, Length};
+/// let f = 2.54f32;
+/// assert_eq!(Unit::In.convert_from(&Unit::Cm, f), 1.0f32);
+/// assert_eq!(Unit::Cm.convert_to(&Unit::In, f), 1.0f32);
+/// ```
+///
+/// Create a [`Length`] via multiplication:
+/// ```
+/// # use vsvg::{Unit, Length};
+/// assert_eq!(30.0f32 * Unit::Cm, Length { value: 30.0, unit: Unit::Cm });
+/// assert_eq!(Unit::Mm * 25.0f64, Length { value: 25.0, unit: Unit::Mm });
+/// ```
+///
+/// Convert to/from strings:
+/// ```
+/// # use vsvg::{Unit, Length};
+/// assert_eq!(Unit::Cm.to_str(), "cm");
+/// assert_eq!(Unit::Yd.to_str(), "yd");
+///
+/// assert_eq!(Unit::try_from("m"), Ok(Unit::M));
+/// assert_eq!(Unit::try_from("kilometre"), Ok(Unit::Km));
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Unit {
     Px,
@@ -15,19 +44,6 @@ pub enum Unit {
     Km,
     Pc,
     Pt,
-}
-
-impl From<Unit> for f64 {
-    fn from(unit: Unit) -> Self {
-        unit.to_px()
-    }
-}
-
-impl From<Unit> for f32 {
-    #[allow(clippy::cast_possible_truncation)]
-    fn from(unit: Unit) -> Self {
-        unit.to_px() as f32
-    }
 }
 
 pub const UNITS: [Unit; 11] = [
@@ -46,20 +62,33 @@ pub const UNITS: [Unit; 11] = [
 
 impl Unit {
     #[must_use]
-    pub fn to_px(&self) -> f64 {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn to_px<F: Float>(&self) -> F {
         match &self {
-            Self::Px => 1.0,
-            Self::In => 96.0,
-            Self::Ft => 12.0 * 96.0,
-            Self::Yd => 36.0 * 96.0,
-            Self::Mi => 1760.0 * 36.0 * 96.0,
-            Self::Mm => 96.0 / 25.4,
-            Self::Cm => 96.0 / 2.54,
-            Self::M => 100.0 * 96.0 / 2.54,
-            Self::Km => 100_000.0 * 96.0 / 2.54,
-            Self::Pc => 16.0,
-            Self::Pt => 96.0 / 72.0,
+            Self::Px => F::one(),
+            Self::In => F::from(96.0).unwrap(),
+            Self::Ft => F::from(12.0 * 96.0).unwrap(),
+            Self::Yd => F::from(36.0 * 96.0).unwrap(),
+            Self::Mi => F::from(1760.0 * 36.0 * 96.0).unwrap(),
+            Self::Mm => F::from(96.0 / 25.4).unwrap(),
+            Self::Cm => F::from(96.0 / 2.54).unwrap(),
+            Self::M => F::from(100.0 * 96.0 / 2.54).unwrap(),
+            Self::Km => F::from(100_000.0 * 96.0 / 2.54).unwrap(),
+            Self::Pc => F::from(16.0).unwrap(),
+            Self::Pt => F::from(96.0 / 72.0).unwrap(),
         }
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn convert_from<F: Float>(&self, from_unit: &Unit, value: F) -> F {
+        value * from_unit.to_px() / self.to_px()
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn convert_to<F: Float>(&self, to_unit: &Unit, value: F) -> F {
+        value * self.to_px() / to_unit.to_px()
     }
 
     #[must_use]
@@ -78,54 +107,89 @@ impl Unit {
             Self::Pt => "pt",
         }
     }
+}
 
-    #[must_use]
-    pub fn from(s: &str) -> Option<Self> {
-        match s.to_lowercase().as_str() {
-            "px" | "pixel" => Some(Unit::Px),
-            "in" | "inch" => Some(Unit::In),
-            "ft" | "feet" => Some(Unit::Ft),
-            "yd" | "yard" => Some(Unit::Yd),
-            "mi" | "mile" | "miles" => Some(Unit::Mi),
-            "mm" | "millimeter" | "millimetre" => Some(Unit::Mm),
-            "cm" | "centimeter" | "centimetre" => Some(Unit::Cm),
-            "m" | "meter" | "metre" => Some(Unit::M),
-            "km" | "kilometer" | "kilometre" => Some(Unit::Km),
-            "pc" | "pica" => Some(Unit::Pc),
-            "pt" | "point" | "points" => Some(Unit::Pt),
-            _ => None,
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum UnitError {
+    #[error("Unrecognised unit '{0}'")]
+    UnrecognisedError(String),
+}
+
+impl TryFrom<&str> for Unit {
+    type Error = UnitError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "px" | "pixel" => Ok(Unit::Px),
+            "in" | "inch" => Ok(Unit::In),
+            "ft" | "feet" => Ok(Unit::Ft),
+            "yd" | "yard" => Ok(Unit::Yd),
+            "mi" | "mile" | "miles" => Ok(Unit::Mi),
+            "mm" | "millimeter" | "millimetre" => Ok(Unit::Mm),
+            "cm" | "centimeter" | "centimetre" => Ok(Unit::Cm),
+            "m" | "meter" | "metre" => Ok(Unit::M),
+            "km" | "kilometer" | "kilometre" => Ok(Unit::Km),
+            "pc" | "pica" => Ok(Unit::Pc),
+            "pt" | "point" | "points" => Ok(Unit::Pt),
+            _ => Err(UnitError::UnrecognisedError(value.to_owned())),
         }
     }
 }
 
-impl std::ops::Mul<Unit> for f64 {
-    type Output = f64;
-
-    fn mul(self, rhs: Unit) -> f64 {
-        self * rhs.to_px()
+impl Display for Unit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.to_str().fmt(f)
     }
 }
 
-impl std::ops::Mul<f64> for Unit {
-    type Output = f64;
+impl<F: Float + AsPrimitive<f64>> std::ops::Mul<F> for Unit {
+    type Output = Length;
 
-    fn mul(self, rhs: f64) -> Self::Output {
-        self.to_px() * rhs
+    fn mul(self, rhs: F) -> Self::Output {
+        Self::Output::new(rhs, self)
     }
 }
 
-impl std::ops::Div<Unit> for f64 {
-    type Output = f64;
+impl<F: Float + AsPrimitive<f64>> std::ops::Mul<F> for &'_ Unit {
+    type Output = Length;
 
-    fn div(self, rhs: Unit) -> f64 {
-        self / rhs.to_px()
+    fn mul(self, rhs: F) -> Self::Output {
+        Self::Output::new(rhs, *self)
     }
 }
 
-impl std::ops::Div<f64> for Unit {
-    type Output = f64;
+// Orphan rule requires us to unroll these.
+macro_rules! unit_trait_impl {
+    ($t:ty) => {
+        impl From<Unit> for $t {
+            fn from(value: Unit) -> $t {
+                value.to_px()
+            }
+        }
 
-    fn div(self, rhs: f64) -> Self::Output {
-        self.to_px() / rhs
-    }
+        impl From<&'_ Unit> for $t {
+            fn from(value: &'_ Unit) -> $t {
+                value.to_px()
+            }
+        }
+
+        impl std::ops::Mul<Unit> for $t {
+            type Output = Length;
+
+            fn mul(self, rhs: Unit) -> Self::Output {
+                Self::Output::new(self, rhs)
+            }
+        }
+
+        impl std::ops::Mul<&'_ Unit> for $t {
+            type Output = Length;
+
+            fn mul(self, rhs: &'_ Unit) -> Self::Output {
+                Self::Output::new(self, *rhs)
+            }
+        }
+    };
 }
+
+unit_trait_impl!(f32);
+unit_trait_impl!(f64);

--- a/crates/whiskers/src/runner/page_size.rs
+++ b/crates/whiskers/src/runner/page_size.rs
@@ -119,17 +119,16 @@ impl PageSizeOptions {
                                 ui.selectable_value(&mut unit, *u, u.to_str());
                             }
                         });
-                    let factor = orig_unit.to_px() / unit.to_px();
-                    w *= factor;
-                    h *= factor;
+                    w = unit.convert_from(&orig_unit, w);
+                    h = unit.convert_from(&orig_unit, h);
                 });
 
                 PageSize::Custom(w, h, unit)
             } else {
                 ui.label(format!(
                     "{:.1}x{:.1} mm",
-                    new_page_size.w() / Unit::Mm,
-                    new_page_size.h() / Unit::Mm
+                    Unit::Mm.convert(new_page_size.w()),
+                    Unit::Mm.convert(new_page_size.h()),
                 ));
 
                 new_page_size


### PR DESCRIPTION
**BREAKING**: this change the semantics of the float/`Unit` multiplication and remove the division.

---

From the docstrings:

#### `Unit`

Convert between units:
```rust
let f = 2.54f32;
assert_eq!(Unit::In.convert_from(&Unit::Cm, f), 1.0f32);
assert_eq!(Unit::Cm.convert_to(&Unit::In, f), 1.0f32);
```

Create a [`Length`] via multiplication:
```rust
assert_eq!(30.0f32 * Unit::Cm, Length { value: 30.0, unit: Unit::Cm });
assert_eq!(Unit::Mm * 25.0f64, Length { value: 25.0, unit: Unit::Mm });
```

Convert to/from strings:
```rust
assert_eq!(Unit::Cm.to_str(), "cm");
assert_eq!(Unit::Yd.to_str(), "yd");

assert_eq!(Unit::try_from("m"), Ok(Unit::M));
assert_eq!(Unit::try_from("kilometre"), Ok(Unit::Km));
```

#### `Length`

A [`Length`] can be created with [`Length::new`], by multiplying a float with a [`Unit`], or
using the shorthand constructors:
```rust
assert_eq!(Length::new(0.0356, Unit::Cm), 0.0356 * Unit::Cm);
assert_eq!(Length::new(0.0356, Unit::Cm), Length::cm(0.0356));
```

All float conversion assume the default [`Unit`] of [`Unit::Px`]:
```rust
assert_eq!(Length::from(96.0), Length::new(96., Unit::Px));
assert_eq!(f64::from(1.0 * Unit::In), 96.0);
```

The usual arithmetic operations are supported.

**Note**: Floats are always considered as [`Unit::Px`]. When adding or subtracting two
[`Length`]s, the result will have the [`Unit`] of the left-hand side.

```rust
// Negation is supported.
assert_eq!(-Length::new(1.0, Unit::In), -1.0 * Unit::In);

// The result has the unit of the left-hand side.
assert_eq!(1.0 * Unit::In + 2.54 * Unit::Cm, 2.0 * Unit::In);
assert_eq!(5.08 * Unit::Cm - 1.0 * Unit::In, 2.54 * Unit::Cm);

// Floats are considered pixels.
assert_eq!(1.0 * Unit::In + 96.0, 2.0 * Unit::In);
assert_eq!(96.0 + 1.0 * Unit::In , 2.0 * Unit::In);
assert_eq!(2.0 * Unit::In - 96.0, 1.0 * Unit::In);
assert_eq!(96.0 - 0.5 * Unit::In, 0.5 * Unit::In);

// Multiplication and division by floats is supported.
// Note: dividing by a `Length` is not supported.
assert_eq!((1.0 * Unit::In) * 2.0, 2.0 * Unit::In);
assert_eq!(2.0 * (1.0 * Unit::In), 2.0 * Unit::In);
assert_eq!((1.0 * Unit::In) / 2.0, 0.5 * Unit::In);
```

[`Length`] implements [`From`] for [`Unit`], so you can use [`Unit`] as a shorthand:
```rust
assert_eq!(Length::from(Unit::In), Length::new(1., Unit::In));
```

A [`Length`] with a different [`Unit`] can be converted using [`Length::convert_to`]:
```rust
let l = Length::new(2.54, Unit::Cm);
assert_eq!(l.convert_to(Unit::In), 1.0 * Unit::In);
```

[`Length`] delegates [`Display`] to [`f64`], so it supports the standard float formatting
syntax:
```rust
let l = Length::new(0.0356, vsvg::Unit::Cm);
assert_eq!(format!("{l:.2}"), "0.04cm");
```
