### PR TITLE
Add options to override pen width and opacity

### DIFF
--- a/crates/vsvg-viewer/src/document_widget.rs
+++ b/crates/vsvg-viewer/src/document_widget.rs
@@ -1,4 +1,4 @@
-use crate::engine::{DisplayMode, Engine, ViewerOptions};
+use crate::engine::{DisplayMode, DisplayOptions, Engine, ViewerOptions};
 use eframe::egui_wgpu;
 use eframe::egui_wgpu::CallbackResources;
 use eframe::epaint::PaintCallbackInfo;
@@ -275,7 +275,12 @@ impl DocumentWidget {
             ui.horizontal(|ui| {
                 ui.label("AA:");
                 ui.add(egui::Slider::new(
-                    &mut self.viewer_options.lock().unwrap().anti_alias,
+                    &mut self
+                        .viewer_options
+                        .lock()
+                        .unwrap()
+                        .display_options
+                        .anti_alias,
                     0.0..=2.0,
                 ))
                 .on_hover_text("Renderer anti-aliasing (default: 0.5)");
@@ -297,6 +302,21 @@ impl DocumentWidget {
                 )
                 .on_hover_text("Tolerance for rendering curves (default: 0.01)");
             });
+
+            ui.separator();
+
+            if ui
+                .button("Reset")
+                .on_hover_text("Reset all display options to the default")
+                .clicked()
+            {
+                let options = &mut self.viewer_options.lock().unwrap().display_options;
+                *options = DisplayOptions {
+                    anti_alias: options.anti_alias,
+                    ..DisplayOptions::default()
+                };
+                ui.close_menu();
+            }
         });
     }
 

--- a/crates/vsvg-viewer/src/engine.rs
+++ b/crates/vsvg-viewer/src/engine.rs
@@ -43,6 +43,9 @@ pub(crate) struct DisplayOptions {
     /// tolerance parameter used for flattening curves by the renderer
     pub tolerance: f64,
 
+    /// anti alias parameter
+    pub anti_alias: f32,
+
     /// display options specific to the line painter
     pub line_display_options: LineDisplayOptions,
 }
@@ -54,12 +57,13 @@ impl Default for DisplayOptions {
             show_pen_up: false,
             show_bezier_handles: false,
             tolerance: crate::DEFAULT_RENDERER_TOLERANCE,
+            anti_alias: 0.5,
             line_display_options: LineDisplayOptions::default(),
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ViewerOptions {
     //TODO: implement that
     /// display mode
@@ -72,24 +76,8 @@ pub(crate) struct ViewerOptions {
     #[serde(skip)]
     pub layer_visibility: HashMap<LayerID, bool>,
 
-    /// anti alias parameter
-    #[serde(skip)]
-    pub anti_alias: f32,
-
     /// vertex count (updated by [`Engine::paint`] for display purposes)
     pub vertex_count: u64,
-}
-
-impl Default for ViewerOptions {
-    fn default() -> Self {
-        Self {
-            display_mode: DisplayMode::default(),
-            display_options: DisplayOptions::default(),
-            layer_visibility: HashMap::default(),
-            anti_alias: 0.5,
-            vertex_count: 0,
-        }
-    }
 }
 
 #[repr(C)]
@@ -356,7 +344,11 @@ impl Engine {
             projection(origin, scale, rect.width(), rect.height()),
             scale,
             (rect.width(), rect.height()),
-            self.viewer_options.lock().unwrap().anti_alias,
+            self.viewer_options
+                .lock()
+                .unwrap()
+                .display_options
+                .anti_alias,
         );
 
         queue.write_buffer(

--- a/crates/vsvg-viewer/src/engine.rs
+++ b/crates/vsvg-viewer/src/engine.rs
@@ -1,5 +1,6 @@
 use crate::painters::{
-    BasicPainter, LinePainter, PageSizePainter, PageSizePainterData, Painter, PointPainter,
+    BasicPainter, LineDisplayOptions, LinePainter, PageSizePainter, PageSizePainterData, Painter,
+    PointPainter,
 };
 use eframe::egui_wgpu::RenderState;
 use std::collections::HashMap;
@@ -28,6 +29,7 @@ pub(crate) enum DisplayMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[allow(clippy::struct_field_names)]
 pub(crate) struct DisplayOptions {
     /// show points
     pub show_display_vertices: bool,
@@ -40,6 +42,9 @@ pub(crate) struct DisplayOptions {
 
     /// tolerance parameter used for flattening curves by the renderer
     pub tolerance: f64,
+
+    /// display options specific to the line painter
+    pub line_display_options: LineDisplayOptions,
 }
 
 impl Default for DisplayOptions {
@@ -49,6 +54,7 @@ impl Default for DisplayOptions {
             show_pen_up: false,
             show_bezier_handles: false,
             tolerance: crate::DEFAULT_RENDERER_TOLERANCE,
+            line_display_options: LineDisplayOptions::default(),
         }
     }
 }
@@ -61,12 +67,6 @@ pub(crate) struct ViewerOptions {
 
     /// display options
     pub display_options: DisplayOptions,
-
-    /// override width
-    pub override_width: Option<f32>,
-
-    /// override opacity
-    pub override_opacity: Option<f32>,
 
     /// layer visibility
     #[serde(skip)]
@@ -85,8 +85,6 @@ impl Default for ViewerOptions {
         Self {
             display_mode: DisplayMode::default(),
             display_options: DisplayOptions::default(),
-            override_width: None,
-            override_opacity: None,
             layer_visibility: HashMap::default(),
             anti_alias: 0.5,
             vertex_count: 0,

--- a/crates/vsvg-viewer/src/painters/mod.rs
+++ b/crates/vsvg-viewer/src/painters/mod.rs
@@ -7,7 +7,7 @@ use vsvg::Point;
 use wgpu::RenderPass;
 
 pub(crate) use basic_painter::{BasicPainter, BasicPainterData};
-pub(crate) use line_painter::{LinePainter, LinePainterData};
+pub(crate) use line_painter::{LineDisplayOptions, LinePainter, LinePainterData};
 pub(crate) use page_size_painter::{PageSizePainter, PageSizePainterData};
 pub(crate) use point_painter::{PointPainter, PointPainterData};
 


### PR DESCRIPTION
Override pen width:

<img width="409" alt="image" src="https://github.com/abey79/vsvg/assets/49431240/95e20d1d-1b88-4431-bfe2-d982073118b4">

<br/>
<br/>

Override opacity:

<img width="391" alt="image" src="https://github.com/abey79/vsvg/assets/49431240/d01374bb-648f-4d33-978e-6d715c9e4a53">
