### PR TITLE
Persist sketch parameters across app relaunch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,18 +3384,18 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/vsvg/src/color.rs
+++ b/crates/vsvg/src/color.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Color {
     pub r: u8,
     pub g: u8,

--- a/crates/vsvg/src/path/point.rs
+++ b/crates/vsvg/src/path/point.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Point {
     data: [f64; 2],
 }

--- a/crates/whiskers-derive/src/lib.rs
+++ b/crates/whiskers-derive/src/lib.rs
@@ -11,6 +11,46 @@ fn format_label(label: &str) -> String {
     format!("{}:", label.to_case(Case::Lower))
 }
 
+/// Attribute macro to automatically derive some of the required traits for a sketch app.
+///
+/// This is equivalent to:
+/// ```ignore
+/// #[derive(Sketch, serde::Serialize, serde::Deserialize)]
+/// #[serde(crate = "::whiskers::prelude::serde")]
+/// ```
+#[proc_macro_attribute]
+pub fn sketch_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(item as DeriveInput);
+
+    let expanded = quote! {
+        #[derive(Sketch, serde::Serialize, serde::Deserialize)]
+        #[serde(crate = "::whiskers::prelude::serde")]
+        #ast
+    };
+
+    TokenStream::from(expanded)
+}
+
+/// Attribute macro to automatically derive some of the required traits for a sketch widget.
+///
+/// This is equivalent to:
+/// ```ignore
+/// #[derive(Widget, serde::Serialize, serde::Deserialize)]
+/// #[serde(crate = "::whiskers::prelude::serde")]
+/// ```
+#[proc_macro_attribute]
+pub fn sketch_widget(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(item as DeriveInput);
+
+    let expanded = quote! {
+        #[derive(Widget, serde::Serialize, serde::Deserialize)]
+        #[serde(crate = "::whiskers::prelude::serde")]
+        #ast
+    };
+
+    TokenStream::from(expanded)
+}
+
 #[proc_macro_derive(Sketch, attributes(param, skip))]
 pub fn sketch_derive(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);

--- a/crates/whiskers-web-demo/src/lib.rs
+++ b/crates/whiskers-web-demo/src/lib.rs
@@ -4,7 +4,7 @@
 use itertools::iproduct;
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 pub struct WhiskersDemoSketch {
     col_count: u32,
     row_count: u32,

--- a/crates/whiskers/README.md
+++ b/crates/whiskers/README.md
@@ -28,7 +28,7 @@ Here is the code for a basic sketch:
 ```rust
 use whiskers::prelude::*;
 
-#[derive(Sketch)]  // <- this is the magic to make the sketch interactive
+#[sketch_app]  // <- this is the magic to make the sketch interactive
 struct HelloWorldSketch {
     width: f64,   // <- interactive UI is automagically built for these fields
     height: f64,
@@ -82,7 +82,7 @@ This is the result:
 - [x] Random Number Generator UI with seed control (see e.g. `asteroid` example).
 - [x] Integrated profiler (based on [puffin](https://github.com/EmbarkStudios/puffin)).
 - [x] `Grid` helper for grid-based sketches.
-- [x] `HexGrid` helper for hexagonal-grid-based sketches 
+- [x] `HexGrid` helper for hexagonal-grid-based sketches
 - [ ] Configuration handling (save/restore config, etc.).
 - [ ] Compiled sketches are *also* a flexible CLI utility with the capability to batch generate sketch outputs with parameter ranges.
 - [ ] Export to other format through templating (HPGL, g-code, etc. — for now, please use [*vpype*](https://github.com/abey79/vpype)).

--- a/crates/whiskers/examples/animation_demo.rs
+++ b/crates/whiskers/examples/animation_demo.rs
@@ -4,7 +4,7 @@
 use std::f64::consts::TAU;
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 struct AnimationDemoSketch {
     #[param(min = 3, max = 15)]
     ngon_sides: usize,

--- a/crates/whiskers/examples/app_demo.rs
+++ b/crates/whiskers/examples/app_demo.rs
@@ -1,6 +1,6 @@
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 struct MySketch {
     #[param(slider, min = 0.0, max = 10.0, step = 2.0)]
     rate: f64,

--- a/crates/whiskers/examples/asteroid.rs
+++ b/crates/whiskers/examples/asteroid.rs
@@ -11,7 +11,7 @@ use rand_distr::{Distribution, Normal};
 use std::f64::consts::PI;
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 struct AsteroidSketch {
     #[param(slider, min = 0.1, max = 1.5)]
     irregularity: f64,

--- a/crates/whiskers/examples/bezpath.rs
+++ b/crates/whiskers/examples/bezpath.rs
@@ -5,7 +5,7 @@
 
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 struct BezpathSketch {
     // path 1
     move_to: Point,

--- a/crates/whiskers/examples/catmull_rom.rs
+++ b/crates/whiskers/examples/catmull_rom.rs
@@ -1,6 +1,6 @@
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 struct CatmullRomSketch {
     #[param(slider, min = 3, max = 1500)]
     num_points: usize,

--- a/crates/whiskers/examples/custom_ui.rs
+++ b/crates/whiskers/examples/custom_ui.rs
@@ -2,7 +2,7 @@ use egui::Ui;
 use whiskers::prelude::*;
 
 /// Very custom data structure that is not supported by default
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 struct GrayRed {
     gray: f64,
     red: f64,
@@ -85,7 +85,7 @@ register_widget_ui!(GrayRed, GrayRedWidget);
 // =================================================================================
 // from here on, we're back to super standard  sketch code...
 
-#[derive(Sketch)]
+#[sketch_app]
 struct CustomUISketch {
     // these param key/value will call into the [`GrayRedWidget`]'s builder methods.
     #[param(underline, label_color = egui::Color32::BLUE)]

--- a/crates/whiskers/examples/grid.rs
+++ b/crates/whiskers/examples/grid.rs
@@ -2,7 +2,7 @@
 
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 struct GridSketch {
     #[param(slider, min = 20.0, max = 400.0)]
     width: f64,

--- a/crates/whiskers/examples/hello_world.rs
+++ b/crates/whiskers/examples/hello_world.rs
@@ -1,6 +1,6 @@
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 struct HelloWorldSketch {
     width: f64,
     height: f64,

--- a/crates/whiskers/examples/hex_grid.rs
+++ b/crates/whiskers/examples/hex_grid.rs
@@ -1,7 +1,7 @@
 //! This example demonstrates the use of the [`HexGrid`] helper.
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 struct HexGridSketch {
     is_pointy_orientation: bool,
     #[param(slider, min = 2, max = 20)]

--- a/crates/whiskers/examples/noise.rs
+++ b/crates/whiskers/examples/noise.rs
@@ -4,7 +4,7 @@ use noise::{Fbm, NoiseFn, Perlin};
 use rayon::prelude::*;
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 struct NoiseSketch {
     #[param(slider, min = 0.0, max = 500.0)]
     margin: f64,

--- a/crates/whiskers/examples/rng.rs
+++ b/crates/whiskers/examples/rng.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 use vsvg::COLORS;
 use whiskers::prelude::*;
 
-#[derive(Sketch)]
+#[sketch_app]
 struct RngSketch {
     width: f64,
     height: f64,

--- a/crates/whiskers/examples/ui_demo.rs
+++ b/crates/whiskers/examples/ui_demo.rs
@@ -3,7 +3,8 @@
 
 use whiskers::prelude::*;
 
-#[derive(Sketch, Default)]
+#[sketch_app]
+#[derive(Default)]
 struct UiDemoSketch {
     // all basic numerical types are supported
     int_64: i64,
@@ -40,7 +41,8 @@ struct UiDemoSketch {
 // the [`whiskers::widgets::WidgetMapper`] trait can be implemented manually, see the `custom_ui`
 // example.
 // Note: all types must implement [`Default`].
-#[derive(Widget, Default)]
+#[sketch_widget]
+#[derive(Default)]
 struct CustomStruct {
     #[param(min = 0.0)]
     some_float: f64,
@@ -53,7 +55,8 @@ struct CustomStruct {
 }
 
 // Tuple structs are supported too
-#[derive(Widget, Default)]
+#[sketch_widget]
+#[derive(Default)]
 struct CustomStructUnnamed(bool, String);
 
 impl App for UiDemoSketch {

--- a/crates/whiskers/src/lib.rs
+++ b/crates/whiskers/src/lib.rs
@@ -14,7 +14,7 @@
 //! ```no_run
 //! use whiskers::prelude::*;
 //!
-//! #[derive(Sketch)]
+//! #[sketch_app]
 //! struct MySketch {
 //!     /* add sketch parameters here */
 //! }
@@ -60,7 +60,7 @@
 //! use whiskers::prelude::*;
 //! use whiskers::wasm_main;
 //!
-//! #[derive(Sketch)]
+//! #[sketch_app]
 //! struct MySketch { }
 //!
 //! impl Default for MySketch {
@@ -135,7 +135,7 @@ pub trait App {
 
 /// This trait is implemented by the [`whiskers_derive::Sketch`] derive macro and makes it possible
 /// for the [`Runner`] to execute your sketch.s
-pub trait SketchApp: App + Default {
+pub trait SketchApp: App + Default + serde::Serialize + serde::de::DeserializeOwned {
     /// Create a runner for this app.
     fn runner<'a>() -> Runner<'a, Self> {
         Runner::<Self>::new()

--- a/crates/whiskers/src/prelude.rs
+++ b/crates/whiskers/src/prelude.rs
@@ -4,11 +4,13 @@ pub use crate::{
     HexGridCell, InfoOptions, LayoutOptions, PageSizeOptions, Result, Runner, Sketch, SketchApp,
 };
 pub use vsvg::{Color, Draw, IntoBezPath, IntoBezPathTolerance, PageSize, Point, Transforms, Unit};
-pub use whiskers_derive::{Sketch, Widget};
+pub use whiskers_derive::{sketch_app, sketch_widget, Sketch, Widget};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use vsvg_viewer::show;
 
+// re-exports
+pub use ::serde;
 pub use anyhow;
 pub use egui;
 pub use rand::prelude::*;

--- a/crates/whiskers/src/runner/mod.rs
+++ b/crates/whiskers/src/runner/mod.rs
@@ -333,6 +333,10 @@ impl<A: crate::SketchApp> vsvg_viewer::ViewerApp for Runner<'_, A> {
     }
 
     fn load(&mut self, storage: &dyn Storage) {
+        if let Some(app) = eframe::get_value(storage, "whiskers-app") {
+            self.app = app;
+        }
+
         let save_ui: Option<SaveUI> = eframe::get_value(storage, "whiskers-runner-save-ui");
         #[allow(unused_mut)]
         if let Some(mut save_ui) = save_ui {
@@ -358,6 +362,7 @@ impl<A: crate::SketchApp> vsvg_viewer::ViewerApp for Runner<'_, A> {
     }
 
     fn save(&self, storage: &mut dyn Storage) {
+        eframe::set_value(storage, "whiskers-app", &self.app);
         eframe::set_value(storage, "whiskers-runner-save-ui", &self.save_ui);
         eframe::set_value(storage, "whiskers-layout-options", &self.layout_options);
         eframe::set_value(storage, "whiskers-page-size", &self.page_size_options);

--- a/crates/whiskers/src/widgets/mod.rs
+++ b/crates/whiskers/src/widgets/mod.rs
@@ -73,7 +73,8 @@
 //! Now let's consider a hypothetical sketch:
 //! ```rust
 //! # use whiskers::prelude::*;
-//! #[derive(Sketch, Default)]
+//! #[sketch_app]
+//! #[derive(Default)]
 //! struct MySketch {
 //!     #[param(slider, step = 0.1)]
 //!     irregularity: f64,


### PR DESCRIPTION
**BREAKING**: this change adds the requirement for all sketches to implement `serde::{Serialize, Deserialize}`. To minimise the related boilerplate, new `#[sketch_app]` and `#[sketch_widget]` attributes are introduced—see below.

This PR adds persistance of the sketch parameters across relaunches of the app. Resetting the parameters to their default is now done using the reset button (see #91).

Serialising the sketch requires it to implement the `serde::{Serialize, Deserialize}` traits. To minimise the related boilerplate (including adding serde as dependency), a new `#[sketch_app]` attribute proc macro is introduced.

The following code:
```rust
#[sketch_app]
struct MySketch {
    // ...
}
```
is now equivalent to:
```rust
#[derive(Sketch, serde::Serialize, serde::Deserialize)]
#[serde(crate = ::whiskers::prelude::serde)]
struct MySketch {
    // ...
}
```
The `#[serde(...)]` attribute is needed to point the derive macro at the whiskers-exported serde crate.

Likewise, a new `#[sketch_widget]` attribute macro is introduced to derive the `Widget` trait along with serde's.

This PR is also a pre-requisite for saved configurations.