### PR TITLE
Made `Runner::new()`private and update docs accordingly

### DIFF
--- a/crates/whiskers/examples/sketch_only.rs
+++ b/crates/whiskers/examples/sketch_only.rs
@@ -1,4 +1,4 @@
-//! This example demonstrates how to directly use [`whiskers::Sketch`] without using the [`Runner`]
+//! This example demonstrates how to directly use [`whiskers::Sketch`] without using the [`whiskers::Runner`]
 //! API.
 use whiskers::prelude::*;
 

--- a/crates/whiskers/src/prelude.rs
+++ b/crates/whiskers/src/prelude.rs
@@ -1,7 +1,7 @@
 pub use crate::widgets::Widget as _; // bring trait in scope, but avoid name-clash with macro
 pub use crate::{
     register_widget_ui, wasm_sketch, AnimationOptions, App, Context, Grid, GridCell, HexGrid,
-    HexGridCell, InfoOptions, LayoutOptions, PageSizeOptions, Result, Runner, Sketch, SketchApp,
+    HexGridCell, InfoOptions, LayoutOptions, PageSizeOptions, Result, Sketch, SketchApp,
 };
 pub use vsvg::{Color, Draw, IntoBezPath, IntoBezPathTolerance, PageSize, Point, Transforms, Unit};
 pub use whiskers_derive::{sketch_app, sketch_widget, Sketch, Widget};

--- a/crates/whiskers/src/runner/mod.rs
+++ b/crates/whiskers/src/runner/mod.rs
@@ -29,8 +29,8 @@ use vsvg_viewer::DocumentWidget;
 
 /// The [`Runner`] is the main entry point for executing a [`crate::SketchApp`].
 ///
-/// It can be configured using the builder pattern with the `with_*()` functions, and then run
-/// using the [`Runner::run`] method.
+/// A [`Runner`] is typically created using [`crate::SketchApp::runner`]. It can be configured using the builder pattern
+/// with the `with_*()` functions, and then run using the [`Runner::run`] method.
 ///
 /// [`Runner`] implements [`vsvg_viewer::ViewerApp`] to actually display the sketch with a custom,
 /// interactive UI.
@@ -71,7 +71,7 @@ pub struct Runner<'a, A: crate::SketchApp> {
 impl<A: crate::SketchApp> Runner<'_, A> {
     /// Create a new [`Runner`] with the provided [`crate::SketchApp`] instance.
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let app = A::default();
 
         let mut save_ui = SaveUI::default();


### PR DESCRIPTION
Also removed `Runner` from prelude as it's no longer needed.

Follow-up to #91 