### PR TITLE
Add `on_exit()` hook to the `ViewerApp` trait

### DIFF
--- a/crates/vsvg-viewer/src/lib.rs
+++ b/crates/vsvg-viewer/src/lib.rs
@@ -141,6 +141,9 @@ pub trait ViewerApp {
     ///
     /// Use [`eframe::set_value`] to store the data.
     fn save(&self, _storage: &mut dyn eframe::Storage) {}
+
+    /// Hook executed before shutting down the app.
+    fn on_exit(&mut self) {}
 }
 
 /// Show a custom [`ViewerApp`].

--- a/crates/vsvg-viewer/src/viewer.rs
+++ b/crates/vsvg-viewer/src/viewer.rs
@@ -234,4 +234,9 @@ impl eframe::App for Viewer {
         );
         self.viewer_app.save(storage);
     }
+
+    /// Called by the framework before shutting down.
+    fn on_exit(&mut self) {
+        self.viewer_app.on_exit();
+    }
 }


### PR DESCRIPTION
I've not bothered exposing the glow version of the function for simplicity given that it's always possible to retrieve the `glow::Context` from  `eframe::Frame::gl()`, but I do not have strong feelings against exposing it.

