### PR TITLE
Re-export core dependencies

### DIFF
--- a/crates/vsvg/src/lib.rs
+++ b/crates/vsvg/src/lib.rs
@@ -43,19 +43,24 @@ pub use stats::*;
 pub use traits::*;
 pub use unit::*;
 
-// re-export for the `trace` macro
-#[cfg(feature = "puffin")]
-pub use puffin;
-
-// re-export
-#[cfg(feature = "geo")]
-pub use ::geo;
+/// Export of core dependencies.
+pub mod exports {
+    #[cfg(feature = "egui")]
+    pub use ::egui;
+    #[cfg(feature = "geo")]
+    pub use ::geo;
+    pub use ::kurbo;
+    #[cfg(feature = "puffin")]
+    pub use ::puffin;
+    pub use ::serde;
+    pub use ::usvg;
+}
 
 #[macro_export]
 macro_rules! trace_function {
     () => {
         #[cfg(feature = "puffin")]
-        $crate::puffin::profile_function!();
+        $crate::exports::puffin::profile_function!();
     };
 }
 
@@ -63,10 +68,10 @@ macro_rules! trace_function {
 macro_rules! trace_scope {
     ($id:expr) => {
         #[cfg(feature = "puffin")]
-        $crate::puffin::profile_scope!($id);
+        $crate::exports::puffin::profile_scope!($id);
     };
     ($id:expr, $data:expr) => {
         #[cfg(feature = "puffin")]
-        $crate::puffin::profile_scope!($id, $data);
+        $crate::exports::puffin::profile_scope!($id, $data);
     };
 }

--- a/crates/whiskers/src/sketch.rs
+++ b/crates/whiskers/src/sketch.rs
@@ -24,7 +24,7 @@ use vsvg::{
 /// In addition to the basic, primitive draw calls, the [`vsvg::Draw`] trait also provides a more
 /// flexible [`vsvg::Draw::add_path`] function that accepts any type which implements the
 /// [`IntoBezPathTolerance`] trait. This currently includes many types from the [`::kurbo`] and
-/// [`vsvg::geo`] crates.
+/// [`vsvg::exports::geo`] crates.
 ///
 /// # Transformations
 ///


### PR DESCRIPTION
This PR adds a proper re-export of core `vsvg` dependencies:

```rust
/// Export of core dependencies.
pub mod exports {
    #[cfg(feature = "egui")]
    pub use ::egui;
    #[cfg(feature = "geo")]
    pub use ::geo;
    pub use ::kurbo;
    #[cfg(feature = "puffin")]
    pub use ::puffin;
    pub use ::serde;
    pub use ::usvg;
}
```

For example, it's very useful to be able to use `vsvg::exports::kurbo` to make sure to have a compatible version (ie. one that has `IntoBezPathTolerance` implemented).

* Fixes #110 