### PR TITLE
Fix cloning the hex grid cell

### DIFF
--- a/crates/whiskers/src/grid_helpers/hex_grid/cell.rs
+++ b/crates/whiskers/src/grid_helpers/hex_grid/cell.rs
@@ -1,5 +1,6 @@
 use vsvg::{IntoBezPathTolerance, Point};
 
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Orientation {
     Flat,
     Pointy,
@@ -20,6 +21,7 @@ pub(crate) enum Orientation {
 ///     .center(Point::new(21.0, 37.0))
 ///     .size(129.0);
 /// ```
+#[derive(Clone, Debug, PartialEq)]
 pub struct HexGridCell {
     /// Center point of the grid cell
     pub center: Point,


### PR DESCRIPTION
When writing the hex grid helper feature, I forgot about deriving basic traits for the `HexGridCell` struct (as I similarly did for the square grid cell). Which resulted in (me) being unable to clone the cell when needed 😅 .