### PR TITLE
Add `Angle` helper and improve related APIs

### DIFF
--- a/crates/vsvg/Cargo.toml
+++ b/crates/vsvg/Cargo.toml
@@ -24,6 +24,7 @@ lyon_geom.workspace = true
 num-traits.workspace = true
 puffin = { workspace = true, optional = true }
 quick-xml.workspace = true
+rand.workspace = true
 rayon.workspace = true
 regex.workspace = true
 serde.workspace = true
@@ -39,11 +40,10 @@ egui = { workspace = true, optional = true }
 
 # optional dependencies, mainly for Point interop.
 geo = { workspace = true, optional = true }
-glam = { workspace = true,  optional = true }
+glam = { workspace = true, optional = true }
 
 [dev-dependencies]
 approx.workspace = true
-rand.workspace = true
 rand_chacha.workspace = true
 getrandom.workspace = true
 

--- a/crates/vsvg/src/angle.rs
+++ b/crates/vsvg/src/angle.rs
@@ -1,0 +1,210 @@
+use std::str::FromStr;
+
+use num_traits::{AsPrimitive, Float};
+use rand::distributions::uniform::{SampleBorrow, SampleUniform, UniformSampler};
+use rand::Rng;
+
+/// An angle in radians, with facilities for parsing and formatting.
+///
+/// Important: the [`FromStr`] implementation assumes degrees if no unit is provided, as it is used
+/// for user input:
+/// ```rust
+/// # use vsvg::Angle;
+/// assert_eq!("1.0rad".parse::<Angle>(), Ok(Angle::from_rad(1.0)));
+/// assert_eq!("45deg".parse::<Angle>(), Ok(Angle::from_deg(45.0)));
+/// assert_eq!("45".parse::<Angle>(), Ok(Angle::from_deg(45.0)));
+/// ```
+#[derive(
+    Debug, Clone, Default, Copy, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize,
+)]
+pub struct Angle(pub f64);
+
+impl Angle {
+    /// Create an angle from radians.
+    #[must_use]
+    pub fn from_rad(rad: f64) -> Self {
+        Self(rad)
+    }
+
+    /// Create an angle from degrees.
+    #[must_use]
+    pub fn from_deg(deg: f64) -> Self {
+        Self(deg.to_radians())
+    }
+
+    /// Radian value of this angle.
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
+    pub fn rad<F: Float>(&self) -> F {
+        F::from(self.0).unwrap()
+    }
+
+    /// Degree value of this angle.
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
+    pub fn deg<F: Float>(&self) -> F {
+        F::from(self.0.to_degrees()).unwrap()
+    }
+}
+
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum AngleError {
+    #[error("Could not parse number: {0}")]
+    FloatParseError(#[from] std::num::ParseFloatError),
+    #[error("Could not parse unit: {0}")]
+    UnitParseError(String),
+}
+
+impl FromStr for Angle {
+    type Err = AngleError;
+
+    /// Parse from user input. Assumes degrees if no unit is provided.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        let number_str = s.trim_end_matches(|c: char| c.is_alphabetic() || c == '°');
+        let unit_str = &s[number_str.len()..];
+
+        // remove whitespace between number and unit
+        let number_str = number_str.trim();
+
+        let angle = number_str.parse::<f64>()?;
+
+        match unit_str {
+            "rad" | "r" => Ok(Self::from_rad(angle)),
+            "deg" | "d" | "°" | "" => Ok(Self::from_deg(angle)),
+            _ => Err(AngleError::UnitParseError(unit_str.to_string())),
+        }
+    }
+}
+
+impl std::ops::Add<Angle> for Angle {
+    type Output = Self;
+
+    fn add(self, rhs: Angle) -> Self::Output {
+        Self::from_rad(self.0 + rhs.0)
+    }
+}
+
+impl std::ops::Sub<Angle> for Angle {
+    type Output = Self;
+
+    fn sub(self, rhs: Angle) -> Self::Output {
+        Self::from_rad(self.0 - rhs.0)
+    }
+}
+
+impl std::ops::Neg for Angle {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::from_rad(-self.0)
+    }
+}
+
+impl<F: Float + AsPrimitive<f64>> std::ops::Mul<F> for Angle {
+    type Output = Self;
+
+    fn mul(self, rhs: F) -> Self::Output {
+        Self::from_rad(self.0 * rhs.as_())
+    }
+}
+
+impl<F: Float + AsPrimitive<f64>> std::ops::Div<F> for Angle {
+    type Output = Self;
+
+    fn div(self, rhs: F) -> Self::Output {
+        Self::from_rad(self.0 / rhs.as_())
+    }
+}
+
+// Orphan rule requires us to unroll these.
+macro_rules! angle_trait_impl {
+    ($t:ty) => {
+        impl From<Angle> for $t {
+            fn from(angle: Angle) -> Self {
+                angle.rad()
+            }
+        }
+
+        impl From<&'_ Angle> for $t {
+            fn from(angle: &'_ Angle) -> Self {
+                angle.rad()
+            }
+        }
+
+        impl std::ops::Mul<Angle> for $t {
+            type Output = Angle;
+
+            fn mul(self, rhs: Angle) -> Self::Output {
+                rhs.mul(self)
+            }
+        }
+    };
+}
+
+angle_trait_impl!(f32);
+angle_trait_impl!(f64);
+
+// ==========================================
+// `rand` support
+
+pub struct AngleSampler(rand::distributions::uniform::UniformFloat<f64>);
+
+impl UniformSampler for crate::AngleSampler {
+    type X = Angle;
+
+    fn new<B1, B2>(low: B1, high: B2) -> Self
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        Self(rand::distributions::uniform::UniformFloat::new(
+            low.borrow().0,
+            high.borrow().0,
+        ))
+    }
+
+    fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        Self(rand::distributions::uniform::UniformFloat::new_inclusive(
+            low.borrow().0,
+            high.borrow().0,
+        ))
+    }
+
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+        Self::X::from_rad(self.0.sample(rng))
+    }
+}
+
+impl SampleUniform for Angle {
+    type Sampler = crate::AngleSampler;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_angle_from_str() {
+        assert_eq!("0".parse::<Angle>().unwrap(), Angle(0.0));
+        assert_eq!("0.0".parse::<Angle>().unwrap(), Angle(0.0));
+        assert_eq!("1.0rad".parse::<Angle>().unwrap(), Angle(1.0));
+        assert_eq!("1.0r".parse::<Angle>().unwrap(), Angle(1.0));
+
+        assert_eq!("1.0deg".parse::<Angle>().unwrap(), Angle::from_deg(1.0));
+        assert_eq!("1.0d".parse::<Angle>().unwrap(), Angle::from_deg(1.0));
+        assert_eq!("1.0°".parse::<Angle>().unwrap(), Angle::from_deg(1.0));
+
+        // !!!! FromStr assume user input, so defaults to degrees
+        assert_eq!("1.0".parse::<Angle>().unwrap(), Angle::from_deg(1.0));
+
+        assert_eq!(
+            "1.0hello".parse::<Angle>(),
+            Err(AngleError::UnitParseError("hello".to_string()))
+        );
+    }
+}

--- a/crates/vsvg/src/document/document.rs
+++ b/crates/vsvg/src/document/document.rs
@@ -75,7 +75,18 @@ impl Document {
     }
 
     /// Crops the contents to the bounds provided.
-    pub fn crop(&mut self, x_min: f64, y_min: f64, x_max: f64, y_max: f64) {
+    pub fn crop(
+        &mut self,
+        x_min: impl Into<f64>,
+        y_min: impl Into<f64>,
+        x_max: impl Into<f64>,
+        y_max: impl Into<f64>,
+    ) {
+        let x_min = x_min.into();
+        let y_min = y_min.into();
+        let x_max = x_max.into();
+        let y_max = y_max.into();
+
         self.layers.iter_mut().for_each(|(_, layer)| {
             layer.crop(x_min, y_min, x_max, y_max);
         });

--- a/crates/vsvg/src/layer/layer.rs
+++ b/crates/vsvg/src/layer/layer.rs
@@ -105,7 +105,18 @@ impl Layer {
             .collect()
     }
 
-    pub fn crop(&mut self, x_min: f64, y_min: f64, x_max: f64, y_max: f64) -> &Self {
+    pub fn crop(
+        &mut self,
+        x_min: impl Into<f64>,
+        y_min: impl Into<f64>,
+        x_max: impl Into<f64>,
+        y_max: impl Into<f64>,
+    ) -> &Self {
+        let x_min = x_min.into();
+        let y_min = y_min.into();
+        let x_max = x_max.into();
+        let y_max = y_max.into();
+
         self.paths.par_iter_mut().for_each(|path| {
             path.crop(x_min, y_min, x_max, y_max);
         });

--- a/crates/vsvg/src/lib.rs
+++ b/crates/vsvg/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::missing_errors_doc)]
 
+mod angle;
 mod catmull_rom;
 mod color;
 mod crop;
@@ -26,10 +27,9 @@ mod unit;
 #[cfg(feature = "whiskers-widgets")]
 pub mod widgets;
 
-pub use crate::svg::*;
-pub use color::*;
-
+pub use angle::*;
 pub use catmull_rom::*;
+pub use color::*;
 pub use crop::*;
 pub use document::*;
 pub use layer::*;
@@ -40,6 +40,7 @@ pub use page_size::*;
 pub use path::*;
 pub use path_index::*;
 pub use stats::*;
+pub use svg::*;
 pub use traits::*;
 pub use unit::*;
 

--- a/crates/vsvg/src/path/path.rs
+++ b/crates/vsvg/src/path/path.rs
@@ -211,8 +211,19 @@ impl Path {
             .collect()
     }
 
-    pub fn crop(&mut self, x_min: f64, y_min: f64, x_max: f64, y_max: f64) -> &Self {
+    pub fn crop(
+        &mut self,
+        x_min: impl Into<f64>,
+        y_min: impl Into<f64>,
+        x_max: impl Into<f64>,
+        y_max: impl Into<f64>,
+    ) -> &Self {
         crate::trace_function!();
+
+        let x_min = x_min.into();
+        let y_min = y_min.into();
+        let x_max = x_max.into();
+        let y_max = y_max.into();
 
         let new_bezpath = BezPath::from_path_segments(self.data.segments().flat_map(|segment| {
             match segment {

--- a/crates/vsvg/src/traits/draw.rs
+++ b/crates/vsvg/src/traits/draw.rs
@@ -97,12 +97,12 @@ pub trait Draw {
         y: impl Into<f64>,
         rx: impl Into<f64>,
         ry: impl Into<f64>,
-        x_rot: f64,
+        x_rot: impl Into<f64>,
     ) -> &mut Self {
         self.add_path(kurbo::Ellipse::new(
             (x.into(), y.into()),
             (rx.into(), ry.into()),
-            x_rot,
+            x_rot.into(),
         ))
     }
 

--- a/crates/vsvg/src/traits/transforms.rs
+++ b/crates/vsvg/src/traits/transforms.rs
@@ -54,36 +54,25 @@ pub trait Transforms: Sized {
 
     /// Rotate the geometry by `theta` radians around the origin.
     #[inline]
-    fn rotate(&mut self, theta: f64) -> &mut Self {
-        self.transform(&Affine::rotate(theta));
+    fn rotate(&mut self, theta: impl Into<f64>) -> &mut Self {
+        self.transform(&Affine::rotate(theta.into()));
         self
-    }
-
-    /// Rotate the geometry by `theta` degrees around the origin.
-    #[inline]
-    fn rotate_deg(&mut self, theta: f64) -> &mut Self {
-        self.rotate(theta.to_radians())
     }
 
     /// Rotate the geometry by `theta` radians around the point `(cx, cy)`.
     #[inline]
-    fn rotate_around(&mut self, theta: f64, cx: impl Into<f64>, cy: impl Into<f64>) -> &mut Self {
-        let (cx, cy) = (cx.into(), cy.into());
-        let transform =
-            Affine::translate((cx, cy)) * Affine::rotate(theta) * Affine::translate((-cx, -cy));
-        self.transform(&transform);
-        self
-    }
-
-    /// Rotate the geometry by `theta` degrees around the point `(cx, cy)`.
-    #[inline]
-    fn rotate_around_deg(
+    fn rotate_around(
         &mut self,
-        theta: f64,
+        theta: impl Into<f64>,
         cx: impl Into<f64>,
         cy: impl Into<f64>,
     ) -> &mut Self {
-        self.rotate_around(theta.to_radians(), cx.into(), cy.into())
+        let (cx, cy) = (cx.into(), cy.into());
+        let transform = Affine::translate((cx, cy))
+            * Affine::rotate(theta.into())
+            * Affine::translate((-cx, -cy));
+        self.transform(&transform);
+        self
     }
 
     /// Skew the geometry by `kx` and `ky` radians around the origin.

--- a/crates/vsvg/src/unit.rs
+++ b/crates/vsvg/src/unit.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 use num_traits::{AsPrimitive, Float};
 
@@ -37,8 +38,8 @@ pub enum UnitError {
 /// assert_eq!(Unit::Cm.to_str(), "cm");
 /// assert_eq!(Unit::Yd.to_str(), "yd");
 ///
-/// assert_eq!(Unit::try_from("m"), Ok(Unit::M));
-/// assert_eq!(Unit::try_from("kilometre"), Ok(Unit::Km));
+/// assert_eq!("m".parse::<Unit>(), Ok(Unit::M));
+/// assert_eq!("kilometre".parse::<Unit>(), Ok(Unit::Km));
 /// ```
 #[derive(Clone, Copy, Default, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Unit {
@@ -145,10 +146,10 @@ impl Unit {
     }
 }
 
-impl TryFrom<&str> for Unit {
-    type Error = UnitError;
+impl FromStr for Unit {
+    type Err = UnitError;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value.to_lowercase().as_str() {
             "px" | "pixel" => Ok(Unit::Px),
             "in" | "inch" => Ok(Unit::In),

--- a/crates/vsvg/src/widgets/angle.rs
+++ b/crates/vsvg/src/widgets/angle.rs
@@ -1,0 +1,104 @@
+use crate::Angle;
+
+/// A widget for [`crate::Angle`].
+#[derive(Default)]
+pub struct AngleWidget {
+    min: Option<f64>,
+    max: Option<f64>,
+    step: Option<f64>,
+    slider: bool,
+    use_rad: bool,
+}
+
+impl AngleWidget {
+    /// Sets the minimum value for the widget.
+    #[must_use]
+    pub fn min(mut self, min: f64) -> Self {
+        self.min = Some(min);
+        self
+    }
+
+    /// Sets the maximum value for the widget.
+    #[must_use]
+    pub fn max(mut self, max: f64) -> Self {
+        self.max = Some(max);
+        self
+    }
+
+    /// Sets the step value for the widget.
+    ///
+    /// This parameter is passed to [`egui::DragValue::speed`] in normal mode, and
+    /// [`egui::Slider::step_by`] in slider mode.
+    #[must_use]
+    pub fn step(mut self, step: f64) -> Self {
+        self.step = Some(step);
+        self
+    }
+
+    /// Sets whether the widget should be displayed as a slider or not.
+    #[must_use]
+    pub fn slider(mut self, slider: bool) -> Self {
+        self.slider = slider;
+        self
+    }
+
+    /// Use degrees as unit.
+    #[must_use]
+    pub fn deg(mut self, use_deg: bool) -> Self {
+        self.use_rad = !use_deg;
+        self
+    }
+
+    /// Use radians as unit.
+    #[must_use]
+    pub fn rad(mut self, use_rad: bool) -> Self {
+        self.use_rad = use_rad;
+        self
+    }
+}
+
+impl whiskers_widgets::Widget<Angle> for AngleWidget {
+    fn ui(&self, ui: &mut egui::Ui, label: &str, value: &mut Angle) -> bool {
+        ui.add(egui::Label::new(label));
+
+        let mut angle_value = if self.use_rad {
+            value.rad()
+        } else {
+            value.deg()
+        };
+
+        ui.horizontal(|ui| {
+            ui.spacing_mut().slider_width -= 40.0; // make some room for the combo box
+
+            let range = self.min.unwrap_or(f64::MIN)..=self.max.unwrap_or(f64::MAX);
+            let changed = if self.slider {
+                let mut slider = egui::Slider::new(&mut angle_value, range);
+                if let Some(step) = self.step {
+                    slider = slider.step_by(step);
+                }
+                ui.add(slider).changed()
+            } else {
+                let mut drag_value = egui::DragValue::new(&mut angle_value).clamp_range(range);
+                if let Some(step) = self.step {
+                    drag_value = drag_value.speed(step);
+                }
+                ui.add(drag_value).changed()
+            };
+
+            ui.label(if self.use_rad { "rad" } else { "deg" });
+
+            if changed {
+                *value = if self.use_rad {
+                    Angle::from_rad(angle_value)
+                } else {
+                    Angle::from_deg(angle_value)
+                }
+            }
+
+            changed
+        })
+        .inner
+    }
+}
+
+whiskers_widgets::register_widget_ui!(Angle, AngleWidget);

--- a/crates/vsvg/src/widgets/mod.rs
+++ b/crates/vsvg/src/widgets/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Requires the `whiskers-widgets` feature to be enabled.
 
+pub mod angle;
 pub mod color;
 pub mod length;
 pub mod point;

--- a/crates/whiskers-web-demo/src/lib.rs
+++ b/crates/whiskers-web-demo/src/lib.rs
@@ -10,16 +10,16 @@ pub struct WhiskersDemoSketch {
     row_count: u32,
 
     #[param(slider, min = 0., max = 10.)]
-    offset_cm: f64,
+    offset: Length,
 
     #[param(slider, min = 0., max = 10.)]
-    box_size_cm: f64,
+    box_size: Length,
 
-    #[param(slider, min = 0., max = 90.)]
-    rand_angle_deg: f64,
+    #[param(slider, deg, min = 0., max = 90.)]
+    rand_angle: Angle,
 
     #[param(slider, min = 0., max = 3.)]
-    rand_offset_cm: f64,
+    rand_offset: Length,
 
     #[param(slider, min = 0., max = 10.)]
     stroke_width: f64,
@@ -30,10 +30,10 @@ impl Default for WhiskersDemoSketch {
         Self {
             col_count: 12,
             row_count: 24,
-            offset_cm: 1.,
-            box_size_cm: 1.,
-            rand_angle_deg: 45.,
-            rand_offset_cm: 0.3,
+            offset: 1.0 * Unit::Cm,
+            box_size: 1.0 * Unit::Cm,
+            rand_angle: Angle::from_deg(45.),
+            rand_offset: 0.3 * Unit::Cm,
             stroke_width: 1.0,
         }
     }
@@ -41,22 +41,22 @@ impl Default for WhiskersDemoSketch {
 
 impl App for WhiskersDemoSketch {
     fn update(&mut self, sketch: &mut Sketch, ctx: &mut Context) -> anyhow::Result<()> {
-        sketch.scale(Unit::Cm).stroke_width(self.stroke_width);
+        sketch.stroke_width(self.stroke_width);
 
         for (i, j) in iproduct!(0..self.col_count, 0..self.row_count) {
             sketch.push_matrix_and(|sketch| {
-                sketch.translate(i as f64 * self.offset_cm, j as f64 * self.offset_cm);
+                sketch.translate(i as f64 * self.offset, j as f64 * self.offset);
 
-                let max_angle = self.rand_angle_deg * (j as f64 / self.row_count as f64);
-                let max_offset = self.rand_offset_cm * (j as f64 / self.row_count as f64);
+                let max_angle = self.rand_angle * (j as f64 / self.row_count as f64);
+                let max_offset = self.rand_offset * (j as f64 / self.row_count as f64);
 
                 sketch
-                    .rotate_deg(ctx.rng_range(-max_angle..max_angle))
+                    .rotate(ctx.rng_range(-max_angle..max_angle))
                     .translate(
                         ctx.rng_range(-max_offset..max_offset),
                         ctx.rng_range(-max_offset..max_offset),
                     )
-                    .rect(0., 0., self.box_size_cm, self.box_size_cm);
+                    .rect(0., 0., self.box_size, self.box_size);
             });
         }
 

--- a/crates/whiskers/examples/sketch_only.rs
+++ b/crates/whiskers/examples/sketch_only.rs
@@ -9,7 +9,7 @@ fn main() -> Result {
         .translate(7.0, 6.0)
         .circle(0.0, 0.0, 2.5)
         .translate(1.0, 4.0)
-        .rotate_deg(45.0)
+        .rotate(Angle::from_deg(45.0))
         .rect(0., 0., 4.0, 1.0)
         .show()?
         .save("output.svg")?;

--- a/crates/whiskers/src/prelude.rs
+++ b/crates/whiskers/src/prelude.rs
@@ -3,7 +3,8 @@ pub use crate::{
     LayoutOptions, PageSizeOptions, Result, Sketch, SketchApp,
 };
 pub use vsvg::{
-    Color, Draw, IntoBezPath, IntoBezPathTolerance, Length, PageSize, Point, Transforms, Unit,
+    Angle, Color, Draw, IntoBezPath, IntoBezPathTolerance, Length, PageSize, Point, Transforms,
+    Unit,
 };
 pub use whiskers_widgets;
 pub use whiskers_widgets::Widget as _;

--- a/crates/whiskers/src/sketch.rs
+++ b/crates/whiskers/src/sketch.rs
@@ -93,7 +93,7 @@ use vsvg::{
 ///         .scale(2.0 * Unit::Cm)
 ///         .translate(10.0, 10.0)
 ///         .circle(0.0, 0.0, 3.0)
-///         .rotate_deg(45.0)
+///         .rotate(Angle::from_deg(45.0))
 ///         .rect(0.0, 0.0, 6.5, 0.5)
 ///         .show()?
 ///         .save("circle.svg")?;


### PR DESCRIPTION
This PR introduces `Angle`, an helper to deal with radian/degree angles. It replaces the `rotate_*_deg`  methods of the `Transform` trait, which are removed.

Note: `Angle` uses radians internally, and radians is the expected unit for all APIs. However, when parsing strings without unit, degrees are expected instead (since it's most commonly used). Likewise, the whiskers widget for `Angle` defaults to using degrees for display (can be changed using `#[param(rad)]`.

Also:
- Improve the `Length` with support for `ctx.rnd_range()`.
- Change many APIs to accept `impl Into<f64>` for compatibility with `Length` and `Angle`.
- Add parsing support to `Length` and `Unit`.
- Update the webdemo.