### PR TITLE
Add support for `Vec<T>` sketch parameters

### DIFF
--- a/crates/whiskers-derive/src/lib.rs
+++ b/crates/whiskers-derive/src/lib.rs
@@ -473,27 +473,48 @@ fn chained_call_for_attrs(attrs: &[Attribute]) -> proc_macro2::TokenStream {
 
     let mut chained_calls = proc_macro2::TokenStream::new();
 
-    if let Some(param_attr) = param_attr {
-        let res = param_attr.parse_nested_meta(|meta| {
-            let ident = meta.path.get_ident().expect("expected ident");
-            let value = meta.value();
+    let mut add_chained_call = |meta: syn::meta::ParseNestedMeta, inner: bool| -> syn::Result<()> {
+        let ident = meta.path.get_ident().expect("expected ident");
+        let value = meta.value();
 
-            if value.is_ok() {
-                let mut expr: Expr = meta.input.parse()?;
+        if value.is_ok() {
+            let mut expr: Expr = meta.input.parse()?;
 
-                // replaces occurrences of self with obj
-                ReplaceSelf.visit_expr_mut(&mut expr);
+            // replaces occurrences of self with obj
+            ReplaceSelf.visit_expr_mut(&mut expr);
 
+            if inner {
+                chained_calls.extend(quote! {
+                    .inner(|obj| obj.#ident(#expr))
+                })
+            } else {
                 chained_calls.extend(quote! {
                     .#ident(#expr)
+                });
+            }
+        } else {
+            if inner {
+                chained_calls.extend(quote! {
+                    .inner(|obj| obj.#ident(true))
+
                 });
             } else {
                 chained_calls.extend(quote! {
                     .#ident(true)
                 });
             }
+        }
 
-            Ok(())
+        Ok(())
+    };
+
+    if let Some(param_attr) = param_attr {
+        let res = param_attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("inner") {
+                meta.parse_nested_meta(|meta| add_chained_call(meta, true))
+            } else {
+                add_chained_call(meta, false)
+            }
         });
 
         match res {

--- a/crates/whiskers-derive/src/lib.rs
+++ b/crates/whiskers-derive/src/lib.rs
@@ -492,17 +492,15 @@ fn chained_call_for_attrs(attrs: &[Attribute]) -> proc_macro2::TokenStream {
                     .#ident(#expr)
                 });
             }
-        } else {
-            if inner {
-                chained_calls.extend(quote! {
-                    .inner(|obj| obj.#ident(true))
+        } else if inner {
+            chained_calls.extend(quote! {
+                .inner(|obj| obj.#ident(true))
 
-                });
-            } else {
-                chained_calls.extend(quote! {
-                    .#ident(true)
-                });
-            }
+            });
+        } else {
+            chained_calls.extend(quote! {
+                .#ident(true)
+            });
         }
 
         Ok(())

--- a/crates/whiskers-widgets/src/lib.rs
+++ b/crates/whiskers-widgets/src/lib.rs
@@ -155,7 +155,7 @@ pub trait Widget<T> {
 /// Do not implement this trait manually, instead use the [`crate::register_widget_ui!`] macro.
 pub trait WidgetMapper<T> {
     /// [`Widget`] type associated with the sketch parameter type `T`.
-    type Type: Widget<T> + Default;
+    type Type: Widget<T>;
 }
 
 /// Registers a given [`Widget`] type for given sketch parameter type.

--- a/crates/whiskers-widgets/src/lib.rs
+++ b/crates/whiskers-widgets/src/lib.rs
@@ -103,11 +103,13 @@ mod bool;
 mod numeric;
 mod string;
 mod ui;
+mod vec;
 
 pub use bool::*;
 pub use numeric::*;
 pub use string::*;
 pub use ui::*;
+pub use vec::*;
 
 // reexport whiskers-derive macros
 pub use whiskers_derive::{sketch_app, sketch_widget, Sketch, Widget};
@@ -153,7 +155,7 @@ pub trait Widget<T> {
 /// Do not implement this trait manually, instead use the [`crate::register_widget_ui!`] macro.
 pub trait WidgetMapper<T> {
     /// [`Widget`] type associated with the sketch parameter type `T`.
-    type Type: Widget<T>;
+    type Type: Widget<T> + Default;
 }
 
 /// Registers a given [`Widget`] type for given sketch parameter type.

--- a/crates/whiskers-widgets/src/vec.rs
+++ b/crates/whiskers-widgets/src/vec.rs
@@ -6,7 +6,7 @@ pub struct VecWidget<T>
 where
     T: WidgetMapper<T> + Default,
 {
-    inner: <T as WidgetMapper<T>>::Type,
+    inner: T::Type,
 }
 
 impl<T> VecWidget<T>

--- a/crates/whiskers-widgets/src/vec.rs
+++ b/crates/whiskers-widgets/src/vec.rs
@@ -1,0 +1,65 @@
+use crate::{Widget, WidgetMapper};
+use egui::Ui;
+
+#[derive(Default)]
+pub struct VecWidget<T>
+where
+    T: WidgetMapper<T> + Default,
+{
+    inner: <T as WidgetMapper<T>>::Type,
+}
+
+impl<T> VecWidget<T>
+where
+    T: WidgetMapper<T> + Default,
+{
+    pub fn inner(
+        mut self,
+        update_inner: impl FnOnce(<T as WidgetMapper<T>>::Type) -> <T as WidgetMapper<T>>::Type,
+    ) -> Self {
+        self.inner = update_inner(self.inner);
+        self
+    }
+}
+
+impl<T> Widget<Vec<T>> for VecWidget<T>
+where
+    T: WidgetMapper<T> + Default,
+{
+    fn ui(&self, ui: &mut Ui, label: &str, value: &mut Vec<T>) -> bool {
+        let mut changed = false;
+
+        let inner_use_grid = <T as WidgetMapper<T>>::Type::use_grid();
+
+        //TODO: meaningful summary
+        crate::collapsing_header(ui, label, "", true, |ui| {
+            if inner_use_grid {
+                egui::Grid::new(label).num_columns(2).show(ui, |ui| {
+                    for (i, item) in value.iter_mut().enumerate() {
+                        let item_label = format!("[{i}]:");
+                        changed |= self.inner.ui(ui, &item_label, item);
+                        ui.end_row();
+                    }
+                });
+            } else {
+                for (i, item) in value.iter_mut().enumerate() {
+                    let item_label = format!("[{i}]:");
+                    changed |= self.inner.ui(ui, &item_label, item);
+                }
+            }
+        });
+
+        changed
+    }
+
+    fn use_grid() -> bool {
+        false
+    }
+}
+
+impl<T> WidgetMapper<Vec<T>> for Vec<T>
+where
+    T: WidgetMapper<T> + Default,
+{
+    type Type = VecWidget<T>;
+}

--- a/crates/whiskers/examples/ui_demo.rs
+++ b/crates/whiskers/examples/ui_demo.rs
@@ -59,6 +59,14 @@ struct UiDemoSketch {
 
     #[skip]
     incompatible: IncompatibleStruct,
+
+    // lists of simple types are supported
+    //
+    // Note: the `inner` attribute is used to specify attributes for the inner type (here `f64`)
+    #[param(inner(slider, min = 0.0, max = 10.))]
+    list_of_simple_type: Vec<f64>,
+
+    custom_struct_list: Vec<CustomStruct>,
 }
 
 // If a type doesn't implement [`Widget`], it can still be used, but `#[skip]` must be used. The
@@ -77,7 +85,7 @@ struct IncompatibleStruct {
 #[sketch_widget]
 #[derive(Default)]
 struct CustomStruct {
-    #[param(min = 0.0, max = 1.0)]
+    #[param(min = 0.0, max = 10.0)]
     some_float: f64,
 
     #[param(slider, min = 0.0, max = self.some_float)]


### PR DESCRIPTION
Add support for sketch parameter with type `Vec<T>`, where `T` is a supported type. The UI allows editing each item, as well as removing/adding items.

The `dashed_lines` example now demonstrates this.