### PR TITLE
Fix `sketch_widget` requiring a dependency on the `whiskers-widgets` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4656,7 +4656,6 @@ name = "whiskers-widgets"
 version = "0.6.0-alpha.0"
 dependencies = [
  "egui",
- "serde",
  "whiskers-derive",
 ]
 

--- a/crates/whiskers-derive/src/lib.rs
+++ b/crates/whiskers-derive/src/lib.rs
@@ -25,8 +25,8 @@ pub fn sketch_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(item as DeriveInput);
 
     let expanded = quote! {
-        #[derive(Sketch, serde::Serialize, serde::Deserialize)]
-        #[serde(crate = "::whiskers::prelude::serde")]
+        #[derive(Sketch, ::whiskers::exports::serde::Serialize, ::whiskers::exports::serde::Deserialize)]
+        #[serde(crate = "::whiskers::exports::serde")]
         #ast
     };
 
@@ -38,15 +38,15 @@ pub fn sketch_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// This is equivalent to:
 /// ```ignore
 /// #[derive(Widget, serde::Serialize, serde::Deserialize)]
-/// #[serde(crate = "::whiskers::prelude::serde")]
+/// #[serde(crate = "::whiskers_widgets::exports::serde")]
 /// ```
 #[proc_macro_attribute]
 pub fn sketch_widget(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(item as DeriveInput);
 
     let expanded = quote! {
-        #[derive(Widget, serde::Serialize, serde::Deserialize)]
-        #[serde(crate = "whiskers_widgets::exports::serde")]
+        #[derive(Widget, ::whiskers::exports::serde::Serialize, ::whiskers::exports::serde::Deserialize)]
+        #[serde(crate = "::whiskers::exports::serde")]
         #ast
     };
 
@@ -72,7 +72,7 @@ pub fn sketch_derive(input: TokenStream) -> TokenStream {
                 stringify!(#name).to_string()
             }
 
-            fn ui(&mut self, ui: &mut whiskers_widgets::exports::egui::Ui) -> bool {
+            fn ui(&mut self, ui: &mut ::whiskers::exports::egui::Ui) -> bool {
                 #fields_ui
             }
         }
@@ -105,7 +105,7 @@ fn process_struct(fields: Fields, name: &Ident, widget_name: &Ident) -> TokenStr
         pub struct #widget_name;
 
         impl whiskers_widgets::Widget<#name> for #widget_name {
-            fn ui(&self, ui: &mut whiskers_widgets::exports::egui::Ui, label: &str, value: &mut #name) -> bool {
+            fn ui(&self, ui: &mut ::whiskers::exports::egui::Ui, label: &str, value: &mut #name) -> bool {
                 ::whiskers_widgets::collapsing_header(ui, label.trim_end_matches(':'), "", true, |ui|{
                         #fields_ui
                     })
@@ -231,7 +231,7 @@ fn process_enum(
     };
 
     let combo_code = quote! {
-        whiskers_widgets::exports::egui::ComboBox::from_id_source(#name_string).selected_text(&selected_text).show_ui(ui, |ui| {
+        ::whiskers::exports::egui::ComboBox::from_id_source(#name_string).selected_text(&selected_text).show_ui(ui, |ui| {
             #(
                 ui.selectable_value(&mut selected_text, #ident_strings.to_owned(), #ident_strings);
             )*
@@ -263,7 +263,7 @@ fn process_enum(
             pub struct #widget_name;
 
             impl whiskers_widgets::Widget<#name> for #widget_name {
-                fn ui(&self, ui: &mut whiskers_widgets::exports::egui::Ui, label: &str, value: &mut #name) -> bool {
+                fn ui(&self, ui: &mut ::whiskers::exports::egui::Ui, label: &str, value: &mut #name) -> bool {
                     #pre_combo_code
 
                     ui.label(label);
@@ -371,7 +371,7 @@ fn process_enum(
             Fields::Unit => quote!{
                 (
                     &mut |ui| {
-                        ui.label(whiskers_widgets::exports::egui::RichText::new("no fields for this variant").weak().italics());
+                        ui.label(::whiskers::exports::egui::RichText::new("no fields for this variant").weak().italics());
                         false
                     },
                     &|| false,
@@ -391,18 +391,18 @@ fn process_enum(
         pub struct #widget_name;
 
         impl whiskers_widgets::Widget<#name> for #widget_name {
-            fn ui(&self, ui: &mut whiskers_widgets::exports::egui::Ui, label: &str, value: &mut #name) -> bool {
+            fn ui(&self, ui: &mut ::whiskers::exports::egui::Ui, label: &str, value: &mut #name) -> bool {
 
                 // draw the UI for a bunch of fields, swapping the grid on and off based on grid support
                 fn draw_ui(
-                    ui: &mut whiskers_widgets::exports::egui::Ui,
+                    ui: &mut ::whiskers::exports::egui::Ui,
                     changed: &mut bool,
                     array: &mut [(&mut dyn FnMut(&mut egui::Ui) -> bool, &dyn Fn() -> bool)],
                 ) {
                     let mut cur_index = 0;
                     while cur_index < array.len() {
                         if array[cur_index].1() {
-                            whiskers_widgets::exports::egui::Grid::new(cur_index).num_columns(2).show(ui, |ui| {
+                            ::whiskers::exports::egui::Grid::new(cur_index).num_columns(2).show(ui, |ui| {
                                 while cur_index < array.len() && array[cur_index].1() {
                                     *changed = (array[cur_index].0)(ui) || *changed;
                                     ui.end_row();
@@ -581,7 +581,7 @@ fn process_fields(
     quote! {
         {
             let array: &[(
-                &dyn Fn(&mut whiskers_widgets::exports::egui::Ui, &mut #parent_type) -> bool, // ui code
+                &dyn Fn(&mut ::whiskers::exports::egui::Ui, &mut #parent_type) -> bool, // ui code
                 &dyn Fn() -> bool                                  // use grid predicate
             )] = &[
                 #output
@@ -592,7 +592,7 @@ fn process_fields(
 
             while cur_index < array.len() {
                 if array[cur_index].1() {
-                    whiskers_widgets::exports::egui::Grid::new(cur_index)
+                    ::whiskers::exports::egui::Grid::new(cur_index)
                         .num_columns(2)
                         .show(ui, |ui| {
                             while cur_index < array.len() && array[cur_index].1() {

--- a/crates/whiskers-widgets/Cargo.toml
+++ b/crates/whiskers-widgets/Cargo.toml
@@ -14,4 +14,4 @@ license = "MIT"
 whiskers-derive.workspace = true
 
 egui.workspace = true
-serde.workspace = true
+

--- a/crates/whiskers-widgets/src/lib.rs
+++ b/crates/whiskers-widgets/src/lib.rs
@@ -114,12 +114,6 @@ pub use vec::*;
 // reexport whiskers-derive macros
 pub use whiskers_derive::{sketch_app, sketch_widget, Sketch, Widget};
 
-/// Exported dependencies, for use by whiskers_derive
-pub mod exports {
-    pub use egui;
-    pub use serde;
-}
-
 pub trait WidgetApp {
     /// The name of the sketch, used the window title, the default output file name, and persistent
     /// settings.

--- a/crates/whiskers/src/lib.rs
+++ b/crates/whiskers/src/lib.rs
@@ -116,6 +116,12 @@ pub use sketch::Sketch;
 /// main function.
 pub type Result = anyhow::Result<()>;
 
+/// Re-exports for use by `whiskers-widgets` and `whiskers-derive`.
+pub mod exports {
+    pub use egui;
+    pub use serde;
+}
+
 /// This is the trait that your sketch app must explicitly implement. The [`App::update`] function
 /// is where the sketch draw code goes.
 pub trait App {
@@ -133,7 +139,11 @@ pub trait App {
 /// This trait is implemented by the [`whiskers_widgets::Sketch`] derive macro and makes it possible
 /// for the [`Runner`] to execute your sketch.s
 pub trait SketchApp:
-    App + whiskers_widgets::WidgetApp + Default + serde::Serialize + serde::de::DeserializeOwned
+    App
+    + whiskers_widgets::WidgetApp
+    + Default
+    + crate::exports::serde::Serialize
+    + crate::exports::serde::de::DeserializeOwned
 {
     /// Create a runner for this app.
     fn runner<'a>() -> Runner<'a, Self> {

--- a/crates/whiskers/src/prelude.rs
+++ b/crates/whiskers/src/prelude.rs
@@ -14,9 +14,8 @@ pub use whiskers_widgets::{sketch_app, sketch_widget, Sketch, Widget}; // bring 
 pub use vsvg_viewer::show;
 
 // re-exports
-pub use ::serde;
+pub use crate::exports::{egui, serde};
 pub use anyhow;
-pub use egui;
 pub use rand::prelude::*;
 pub use vsvg::exports::kurbo;
 pub use vsvg_viewer;


### PR DESCRIPTION
Previously, `#[sketch_widget]` would use a reference to the `whiskers-widgets` crate, forcing client code to explicitly depend on said crate. This PR fixes this and cleans up the export. Now `whiskers` exports `serde` and `egu` and these export are exclusively referenced by macro code.