### PR TITLE
Add index property to the grid cell

### DIFF
--- a/crates/whiskers/src/grid_helpers/grid.rs
+++ b/crates/whiskers/src/grid_helpers/grid.rs
@@ -20,6 +20,8 @@ pub struct GridCell {
     pub size: [f64; 2],
     /// Grid's width and height
     pub grid_size: [f64; 2],
+    /// Cell's index in the flattened grid
+    pub index: usize,
 }
 
 impl IntoBezPathTolerance for &GridCell {
@@ -152,6 +154,7 @@ impl Grid {
                     position: Point::new(pos_x, pos_y),
                     size: [module_width, module_height],
                     grid_size,
+                    index: row * columns + column,
                 };
                 callback_fn(sketch, &cell);
             }


### PR DESCRIPTION
For a scenario where iterating on a grid needs to be combined with accessing an item from a 1-dimensional data structure (like a vector), it's useful to have a 1D index of a grid cell to do so.