### PR TITLE
Remove broken .into()

### DIFF
--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -72,7 +72,7 @@ impl PathDataTrait for Polyline {
         self.points()
             .iter()
             .skip(1)
-            .fold(rect, |acc, point| acc.union_pt(point.into()))
+            .fold(rect, |acc, point| acc.union_pt(point))
     }
 
     fn start(&self) -> Option<Point> {


### PR DESCRIPTION
Upon using vsvg I got the following error:
```clippy
error[E0283]: type annotations needed
   --> /home/lauda/Projects/vsvg/crates/vsvg/src/path/flattened_path.rs:75:57
    |
75  |             .fold(rect, |acc, point| acc.union_pt(point.into()))
    |                                          --------       ^^^^
    |                                          |
    |                                          required by a bound introduced by this call
    |
    = note: cannot satisfy `_: Into<kurbo::Point>`
note: required by a bound in `kurbo::Rect::union_pt`
   --> /home/lauda/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/kurbo-0.11.3/src/rect.rs:221:37
    |
221 |     pub fn union_pt(&self, pt: impl Into<Point>) -> Rect {
    |                                     ^^^^^^^^^^^ required by this bound in `Rect::union_pt`
help: try using a fully qualified path to specify the expected types
    |
75  -             .fold(rect, |acc, point| acc.union_pt(point.into()))
75  +             .fold(rect, |acc, point| acc.union_pt(<&point::Point as Into<T>>::into(point)))
    |
help: consider removing this method call, as the receiver has type `&point::Point` and `&point::Point: Into<kurbo::Point>` trivially holds
    |
75  -             .fold(rect, |acc, point| acc.union_pt(point.into()))
75  +             .fold(rect, |acc, point| acc.union_pt(point))
    |

```

I applied the fix in my fork to run vsvg without errors, if more changes are needed for this PR I'm happy to help.