### PR TITLE
Add low-level implementation for path joining and merging optimization

### DIFF
--- a/crates/vsvg/src/layer/mod.rs
+++ b/crates/vsvg/src/layer/mod.rs
@@ -3,7 +3,8 @@ mod flattened_layer;
 mod layer;
 mod metadata;
 
-use crate::{IndexBuilder, PathDataTrait, PathTrait, Point, Transforms};
+use crate::path_index::IndexBuilder;
+use crate::{PathDataTrait, PathTrait, Point, Transforms};
 
 use crate::stats::LayerStats;
 pub use flattened_layer::FlattenedLayer;
@@ -94,6 +95,81 @@ pub trait LayerTrait<P: PathTrait<D>, D: PathDataTrait>: Default + Transforms {
         }
 
         *self.paths_mut() = new_paths;
+    }
+
+    /// Join paths whose endpoints are within tolerance.
+    ///
+    /// If `flip` is true, paths may be reversed to enable more joins.
+    ///
+    /// Unlike [`sort`](LayerTrait::sort) which reorders paths, `join_paths` concatenates
+    /// them, reducing the total path count.
+    ///
+    /// Note: Currently joins are only made at path endpoints. A future enhancement
+    /// could re-loop closed paths when another path's endpoint touches any point
+    /// along the closed path, enabling more joins.
+    fn join_paths(&mut self, tolerance: f64, flip: bool) {
+        if self.paths().len() <= 1 {
+            return;
+        }
+
+        let taken_paths = std::mem::take(self.paths_mut());
+        let mut index = IndexBuilder::default().flip(flip).build(&taken_paths);
+        let mut result: Vec<P> = Vec::new();
+
+        // Start first chain
+        let Some(first_item) = index.pop_first() else {
+            return;
+        };
+        let mut current = first_item.path.clone();
+
+        // Greedy chain building
+        loop {
+            let Some(current_end) = current.end() else {
+                result.push(current);
+                match index.pop_first() {
+                    Some(item) => current = item.path.clone(),
+                    None => break,
+                }
+                continue;
+            };
+
+            // Find nearest path within tolerance
+            if let Some((item, reversed)) = index.pop_nearest(&current_end) {
+                let candidate_start = if reversed {
+                    item.end.unwrap_or(current_end)
+                } else {
+                    item.start.unwrap_or(current_end)
+                };
+
+                if current_end.distance(&candidate_start) <= tolerance {
+                    // Join this path
+                    let mut next = item.path.clone();
+                    if reversed {
+                        next.data_mut().flip();
+                    }
+                    current.join(&next, tolerance);
+                    // Continue trying to extend
+                } else {
+                    // Too far, start new chain
+                    result.push(current);
+                    current = item.path.clone();
+                    if reversed {
+                        current.data_mut().flip();
+                    }
+                }
+            } else {
+                // No more paths in index
+                result.push(current);
+                break;
+            }
+        }
+
+        // Add remaining paths from index (shouldn't happen normally)
+        while let Some(item) = index.pop_first() {
+            result.push(item.path.clone());
+        }
+
+        *self.paths_mut() = result;
     }
 
     fn pen_up_trajectories(&self) -> Vec<(Point, Point)> {

--- a/crates/vsvg/src/layer/mod.rs
+++ b/crates/vsvg/src/layer/mod.rs
@@ -117,4 +117,18 @@ pub trait LayerTrait<P: PathTrait<D>, D: PathDataTrait>: Default + Transforms {
     fn stats(&self) -> LayerStats {
         LayerStats::from_layer(self)
     }
+
+    /// Split all compound paths into individual subpaths.
+    ///
+    /// This is useful before [`Layer::join_paths`](crate::Layer::join_paths) to maximize
+    /// optimization opportunities. When paths contain multiple subpaths (e.g.,
+    /// from SVG imports or boolean operations), only the overall start/end
+    /// points are considered for joining. Exploding first exposes all subpath
+    /// endpoints.
+    ///
+    /// For [`FlattenedLayer`], this is a no-op since polylines cannot be compound.
+    fn explode(&mut self) {
+        let paths = std::mem::take(self.paths_mut());
+        *self.paths_mut() = paths.into_iter().flat_map(P::split).collect();
+    }
 }

--- a/crates/vsvg/src/lib.rs
+++ b/crates/vsvg/src/lib.rs
@@ -57,6 +57,9 @@ pub mod exports {
     pub use ::usvg;
 }
 
+/// Epsilon for considering two points as coincident.
+pub const SAME_POINT_EPSILON: f64 = 1e-10;
+
 #[macro_export]
 macro_rules! trace_function {
     () => {

--- a/crates/vsvg/src/optimization.rs
+++ b/crates/vsvg/src/optimization.rs
@@ -89,35 +89,7 @@ impl Layer {
     pub fn join_paths(&mut self, tolerance: f64, flip: bool) {
         join_paths_impl(&mut self.paths, tolerance, flip);
     }
-}
 
-impl FlattenedLayer {
-    /// Join paths whose endpoints are within tolerance.
-    ///
-    /// If `flip` is true, paths may be reversed to enable more joins.
-    ///
-    /// Unlike [`FlattenedLayer::sort`](crate::LayerTrait::sort) which reorders paths,
-    /// `join_paths` concatenates them, reducing the total path count.
-    ///
-    /// Note: Currently joins are only made at path endpoints. A future enhancement
-    /// could re-loop closed paths when another path's endpoint touches any point
-    /// along the closed path, enabling more joins.
-    #[allow(clippy::missing_panics_doc)]
-    pub fn join_paths(&mut self, tolerance: f64, flip: bool) {
-        join_paths_impl(&mut self.paths, tolerance, flip);
-    }
-
-    /// No-op for `FlattenedLayer`.
-    ///
-    /// [`FlattenedPath`](crate::FlattenedPath) is based on [`Polyline`](crate::Polyline),
-    /// which is always a single connected sequence of points and cannot represent
-    /// compound paths. This method exists for API consistency with [`Layer::explode`].
-    pub fn explode(&mut self) {
-        // No-op: FlattenedPath cannot be compound
-    }
-}
-
-impl Layer {
     /// Sort the paths such as to minimize the pen up distance
     ///
     /// This is done using a greedy algorithm, starting with the layer's first path. Any path that
@@ -153,19 +125,22 @@ impl Layer {
 
         self.paths = new_paths;
     }
+}
 
-    /// Split all compound paths into individual subpaths.
+impl FlattenedLayer {
+    /// Join paths whose endpoints are within tolerance.
     ///
-    /// This is useful before [`join_paths`](Layer::join_paths) to maximize
-    /// optimization opportunities. When paths contain multiple subpaths (e.g.,
-    /// from SVG imports or boolean operations), only the overall start/end
-    /// points are considered for joining. Exploding first exposes all subpath
-    /// endpoints.
+    /// If `flip` is true, paths may be reversed to enable more joins.
     ///
-    /// Paths that are already simple (single subpath) are unchanged.
-    pub fn explode(&mut self) {
-        let paths = std::mem::take(&mut self.paths);
-        self.paths = paths.into_iter().flat_map(crate::Path::split).collect();
+    /// Unlike [`FlattenedLayer::sort`](crate::LayerTrait::sort) which reorders paths,
+    /// `join_paths` concatenates them, reducing the total path count.
+    ///
+    /// Note: Currently joins are only made at path endpoints. A future enhancement
+    /// could re-loop closed paths when another path's endpoint touches any point
+    /// along the closed path, enabling more joins.
+    #[allow(clippy::missing_panics_doc)]
+    pub fn join_paths(&mut self, tolerance: f64, flip: bool) {
+        join_paths_impl(&mut self.paths, tolerance, flip);
     }
 }
 

--- a/crates/vsvg/src/optimization.rs
+++ b/crates/vsvg/src/optimization.rs
@@ -1,5 +1,161 @@
 use crate::path_index::IndexBuilder;
-use crate::{Layer, PathDataTrait, Point};
+use crate::{FlattenedLayer, Layer, PathDataTrait, Point};
+
+impl Layer {
+    /// Join paths whose endpoints are within tolerance.
+    ///
+    /// If `flip` is true, paths may be reversed to enable more joins.
+    ///
+    /// Unlike [`Layer::sort`] which reorders paths, `join_paths` concatenates
+    /// them, reducing the total path count.
+    ///
+    /// Note: Currently joins are only made at path endpoints. A future enhancement
+    /// could re-loop closed paths when another path's endpoint touches any point
+    /// along the closed path, enabling more joins.
+    #[allow(clippy::missing_panics_doc)]
+    pub fn join_paths(&mut self, tolerance: f64, flip: bool) {
+        if self.paths.len() <= 1 {
+            return;
+        }
+
+        let paths = std::mem::take(&mut self.paths);
+        let mut index = IndexBuilder::default().flip(flip).build(&paths);
+        let mut result: Vec<crate::Path> = Vec::new();
+
+        // Start first chain
+        let Some(first_item) = index.pop_first() else {
+            return;
+        };
+        let mut current = (*first_item.path).clone();
+
+        // Greedy chain building
+        loop {
+            let Some(current_end) = current.data.end() else {
+                result.push(current);
+                match index.pop_first() {
+                    Some(item) => current = (*item.path).clone(),
+                    None => break,
+                }
+                continue;
+            };
+
+            // Find nearest path within tolerance
+            if let Some((item, reversed)) = index.pop_nearest(&current_end) {
+                let candidate_start = if reversed {
+                    item.end.unwrap_or(current_end)
+                } else {
+                    item.start.unwrap_or(current_end)
+                };
+
+                if current_end.distance(&candidate_start) <= tolerance {
+                    // Join this path
+                    let mut next = (*item.path).clone();
+                    if reversed {
+                        next.data.flip();
+                    }
+                    current.join(&next, tolerance);
+                    // Continue trying to extend
+                } else {
+                    // Too far, start new chain
+                    result.push(current);
+                    current = (*item.path).clone();
+                    if reversed {
+                        current.data.flip();
+                    }
+                }
+            } else {
+                // No more paths in index
+                result.push(current);
+                break;
+            }
+        }
+
+        // Add remaining paths from index (shouldn't happen normally)
+        while let Some(item) = index.pop_first() {
+            result.push((*item.path).clone());
+        }
+
+        self.paths = result;
+    }
+}
+
+impl FlattenedLayer {
+    /// Join paths whose endpoints are within tolerance.
+    ///
+    /// If `flip` is true, paths may be reversed to enable more joins.
+    ///
+    /// Unlike [`FlattenedLayer::sort`](crate::LayerTrait::sort) which reorders paths,
+    /// `join_paths` concatenates them, reducing the total path count.
+    ///
+    /// Note: Currently joins are only made at path endpoints. A future enhancement
+    /// could re-loop closed paths when another path's endpoint touches any point
+    /// along the closed path, enabling more joins.
+    #[allow(clippy::missing_panics_doc)]
+    pub fn join_paths(&mut self, tolerance: f64, flip: bool) {
+        if self.paths.len() <= 1 {
+            return;
+        }
+
+        let paths = std::mem::take(&mut self.paths);
+        let mut index = IndexBuilder::default().flip(flip).build(&paths);
+        let mut result: Vec<crate::FlattenedPath> = Vec::new();
+
+        // Start first chain
+        let Some(first_item) = index.pop_first() else {
+            return;
+        };
+        let mut current = (*first_item.path).clone();
+
+        // Greedy chain building
+        loop {
+            let Some(current_end) = current.data.end() else {
+                result.push(current);
+                match index.pop_first() {
+                    Some(item) => current = (*item.path).clone(),
+                    None => break,
+                }
+                continue;
+            };
+
+            // Find nearest path within tolerance
+            if let Some((item, reversed)) = index.pop_nearest(&current_end) {
+                let candidate_start = if reversed {
+                    item.end.unwrap_or(current_end)
+                } else {
+                    item.start.unwrap_or(current_end)
+                };
+
+                if current_end.distance(&candidate_start) <= tolerance {
+                    // Join this path
+                    let mut next = (*item.path).clone();
+                    if reversed {
+                        next.data.flip();
+                    }
+                    current.join(&next, tolerance);
+                    // Continue trying to extend
+                } else {
+                    // Too far, start new chain
+                    result.push(current);
+                    current = (*item.path).clone();
+                    if reversed {
+                        current.data.flip();
+                    }
+                }
+            } else {
+                // No more paths in index
+                result.push(current);
+                break;
+            }
+        }
+
+        // Add remaining paths from index (shouldn't happen normally)
+        while let Some(item) = index.pop_first() {
+            result.push((*item.path).clone());
+        }
+
+        self.paths = result;
+    }
+}
 
 impl Layer {
     /// Sort the paths such as to minimize the pen up distance
@@ -36,6 +192,20 @@ impl Layer {
         }
 
         self.paths = new_paths;
+    }
+
+    /// Split all compound paths into individual subpaths.
+    ///
+    /// This is useful before [`join_paths`](Layer::join_paths) to maximize
+    /// optimization opportunities. When paths contain multiple subpaths (e.g.,
+    /// from SVG imports or boolean operations), only the overall start/end
+    /// points are considered for joining. Exploding first exposes all subpath
+    /// endpoints.
+    ///
+    /// Paths that are already simple (single subpath) are unchanged.
+    pub fn explode(&mut self) {
+        let paths = std::mem::take(&mut self.paths);
+        self.paths = paths.into_iter().flat_map(crate::Path::split).collect();
     }
 }
 
@@ -94,5 +264,250 @@ mod tests {
     fn test_sort_problematic_case() {
         let mut doc = Document::from_svg(test_file!("random_100_sort.svg"), false).unwrap();
         doc.get_mut(1).sort(true);
+    }
+
+    // ==================== join_paths tests ====================
+
+    #[test]
+    fn test_join_paths_basic() {
+        let mut layer = FlattenedLayer::default();
+
+        // Two paths that should join: (0,0)->(10,0) and (10,0)->(20,0)
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+        ]));
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(10.0, 0.0),
+            Point::new(20.0, 0.0),
+        ]));
+
+        layer.join_paths(0.1, false);
+
+        assert_eq!(layer.paths.len(), 1);
+        // Should have 3 points (duplicate point at junction is skipped)
+        assert_eq!(layer.paths[0].data.points().len(), 3);
+    }
+
+    #[test]
+    fn test_join_paths_chain_of_three() {
+        let mut layer = FlattenedLayer::default();
+
+        // A: (0,0) -> (10,0)
+        // B: (10,0) -> (10,10)
+        // C: (10,10) -> (0,10)
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+        ]));
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(10.0, 0.0),
+            Point::new(10.0, 10.0),
+        ]));
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(10.0, 10.0),
+            Point::new(0.0, 10.0),
+        ]));
+
+        layer.join_paths(0.1, false);
+
+        assert_eq!(layer.paths.len(), 1);
+        assert_eq!(layer.paths[0].data.points().len(), 4);
+    }
+
+    #[test]
+    fn test_join_paths_with_flip() {
+        let mut layer = FlattenedLayer::default();
+
+        // A: (0,0) -> (10,0)
+        // B: (20,0) -> (10,0)  -- end of B matches end of A, needs flip
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+        ]));
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(20.0, 0.0),
+            Point::new(10.0, 0.0),
+        ]));
+
+        // Without flip: should not join (paths are 2)
+        let mut layer_no_flip = layer.clone();
+        layer_no_flip.join_paths(0.1, false);
+        assert_eq!(layer_no_flip.paths.len(), 2);
+
+        // With flip: should join into 1 path
+        layer.join_paths(0.1, true);
+        assert_eq!(layer.paths.len(), 1);
+    }
+
+    #[test]
+    fn test_join_paths_no_join_too_far() {
+        let mut layer = FlattenedLayer::default();
+
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+        ]));
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(15.0, 0.0), // 5 units away
+            Point::new(25.0, 0.0),
+        ]));
+
+        layer.join_paths(1.0, false); // Tolerance 1.0
+
+        assert_eq!(layer.paths.len(), 2); // No join
+    }
+
+    #[test]
+    fn test_join_paths_closed_path_included() {
+        let mut layer = FlattenedLayer::default();
+
+        // Open path ending at (10,0)
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+        ]));
+
+        // Closed path (square) starting/ending at (10,0)
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(10.0, 0.0),
+            Point::new(10.0, 10.0),
+            Point::new(0.0, 10.0),
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0), // Closed: end == start
+        ]));
+
+        layer.join_paths(0.1, true);
+
+        // Closed paths CAN be joined - open path's end meets closed path's start
+        assert_eq!(layer.paths.len(), 1);
+        // Open path (2 pts) + closed path (5 pts) - 1 duplicate = 6 pts
+        assert_eq!(layer.paths[0].data.points().len(), 6);
+    }
+
+    #[test]
+    fn test_join_paths_tolerance_boundary() {
+        let mut layer = FlattenedLayer::default();
+
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+        ]));
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(11.0, 0.0), // Exactly 1.0 away
+            Point::new(20.0, 0.0),
+        ]));
+
+        // At tolerance: should join
+        layer.join_paths(1.0, false);
+        assert_eq!(layer.paths.len(), 1);
+    }
+
+    #[test]
+    fn test_join_paths_empty_layer() {
+        let mut layer = FlattenedLayer::default();
+        layer.join_paths(1.0, true);
+        assert_eq!(layer.paths.len(), 0);
+    }
+
+    #[test]
+    fn test_join_paths_single_path() {
+        let mut layer = FlattenedLayer::default();
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+        ]));
+
+        layer.join_paths(1.0, true);
+        assert_eq!(layer.paths.len(), 1);
+    }
+
+    // ==================== explode tests ====================
+
+    #[test]
+    fn test_explode_simple_paths() {
+        use crate::Path;
+
+        let mut layer = crate::Layer::default();
+
+        // Add two simple (non-compound) paths
+        layer.paths.push(Path::from_svg("M 0,0 L 10,10").unwrap());
+        layer.paths.push(Path::from_svg("M 20,20 L 30,30").unwrap());
+
+        layer.explode();
+
+        // Should still be 2 paths (no change)
+        assert_eq!(layer.paths.len(), 2);
+    }
+
+    #[test]
+    fn test_explode_compound_path() {
+        use crate::Path;
+
+        let mut layer = crate::Layer::default();
+
+        // Add one compound path with 2 subpaths
+        layer
+            .paths
+            .push(Path::from_svg("M 0,0 L 10,10 M 50,50 L 60,60").unwrap());
+
+        layer.explode();
+
+        // Should now be 2 separate paths
+        assert_eq!(layer.paths.len(), 2);
+        assert_eq!(layer.paths[0].data.start(), Some(Point::new(0.0, 0.0)));
+        assert_eq!(layer.paths[1].data.start(), Some(Point::new(50.0, 50.0)));
+    }
+
+    #[test]
+    fn test_explode_mixed() {
+        use crate::Path;
+
+        let mut layer = crate::Layer::default();
+
+        // Simple path
+        layer.paths.push(Path::from_svg("M 0,0 L 10,10").unwrap());
+        // Compound path with 3 subpaths
+        layer
+            .paths
+            .push(Path::from_svg("M 20,20 L 30,30 M 40,40 L 50,50 M 60,60 L 70,70").unwrap());
+        // Another simple path
+        layer.paths.push(Path::from_svg("M 80,80 L 90,90").unwrap());
+
+        layer.explode();
+
+        // 1 + 3 + 1 = 5 paths
+        assert_eq!(layer.paths.len(), 5);
+    }
+
+    #[test]
+    fn test_explode_empty_layer() {
+        let mut layer = crate::Layer::default();
+        layer.explode();
+        assert_eq!(layer.paths.len(), 0);
+    }
+
+    #[test]
+    fn test_explode_then_join() {
+        use crate::Path;
+
+        let mut layer = crate::Layer::default();
+
+        // Compound path where subpaths are far apart
+        // Subpath 1: (0,0) -> (10,0)
+        // Subpath 2: (10,0) -> (20,0)  -- starts where subpath 1 ends!
+        layer
+            .paths
+            .push(Path::from_svg("M 0,0 L 10,0 M 10,0 L 20,0").unwrap());
+
+        // Before explode: join_paths won't join internal endpoints
+        // The compound path has start=(0,0) and end=(20,0)
+
+        // After explode: we have 2 paths that can be joined
+        layer.explode();
+        assert_eq!(layer.paths.len(), 2);
+
+        layer.join_paths(0.1, false);
+        assert_eq!(layer.paths.len(), 1);
     }
 }

--- a/crates/vsvg/src/optimization.rs
+++ b/crates/vsvg/src/optimization.rs
@@ -413,8 +413,8 @@ mod tests {
         layer.join_paths(0.1, false);
 
         assert_eq!(layer.paths.len(), 1);
-        // BezPath join converts MoveTo to LineTo: M 0,0 L 10,0 + L 10,0 L 20,0 = 4 elements
-        assert_eq!(layer.paths[0].data.elements().len(), 4);
+        // BezPath join drops coincident MoveTo: M 0,0 L 10,0 L 20,0 = 3 elements
+        assert_eq!(layer.paths[0].data.elements().len(), 3);
     }
 
     // ==================== explode tests ====================

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -46,6 +46,24 @@ impl Polyline {
     pub fn into_points(self) -> Vec<Point> {
         self.0
     }
+
+    /// Append another polyline to this one.
+    ///
+    /// If the endpoint of `self` and the start of `other` are within `epsilon`,
+    /// the duplicate point is skipped to avoid redundancy.
+    pub fn join(&mut self, other: &Polyline, epsilon: f64) {
+        if other.0.is_empty() {
+            return;
+        }
+
+        // Check if we should skip the first point of other (duplicate)
+        let skip = match (self.end(), other.start()) {
+            (Some(end), Some(start)) if end.distance(&start) < epsilon => 1,
+            _ => 0,
+        };
+
+        self.0.extend(other.0.iter().skip(skip).copied());
+    }
 }
 
 impl<P: Into<Point>> FromIterator<P> for Polyline {
@@ -146,6 +164,17 @@ impl From<Polyline> for FlattenedPath {
 impl From<Vec<Point>> for FlattenedPath {
     fn from(points: Vec<Point>) -> Self {
         Polyline::new(points).into()
+    }
+}
+
+impl FlattenedPath {
+    /// Append another path to this one.
+    ///
+    /// The underlying polylines are joined, and metadata is merged
+    /// (currently first path's metadata wins).
+    pub fn join(&mut self, other: &FlattenedPath, epsilon: f64) {
+        self.data.join(&other.data, epsilon);
+        self.metadata.merge(&other.metadata);
     }
 }
 

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -150,6 +150,15 @@ impl PathTrait<Polyline> for FlattenedPath {
     fn metadata_mut(&mut self) -> &mut PathMetadata {
         &mut self.metadata
     }
+
+    /// Append another path to this one.
+    ///
+    /// The underlying polylines are joined, and metadata is merged
+    /// (currently first path's metadata wins).
+    fn join(&mut self, other: &FlattenedPath, epsilon: f64) {
+        self.data.join(&other.data, epsilon);
+        self.metadata.merge(&other.metadata);
+    }
 }
 
 impl From<Polyline> for FlattenedPath {
@@ -164,17 +173,6 @@ impl From<Polyline> for FlattenedPath {
 impl From<Vec<Point>> for FlattenedPath {
     fn from(points: Vec<Point>) -> Self {
         Polyline::new(points).into()
-    }
-}
-
-impl FlattenedPath {
-    /// Append another path to this one.
-    ///
-    /// The underlying polylines are joined, and metadata is merged
-    /// (currently first path's metadata wins).
-    pub fn join(&mut self, other: &FlattenedPath, epsilon: f64) {
-        self.data.join(&other.data, epsilon);
-        self.metadata.merge(&other.metadata);
     }
 }
 

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -159,6 +159,11 @@ impl PathTrait<Polyline> for FlattenedPath {
         self.data.join(&other.data, epsilon);
         self.metadata.merge(&other.metadata);
     }
+
+    /// Returns `vec![self]` since polylines cannot represent compound paths.
+    fn split(self) -> Vec<Self> {
+        vec![self]
+    }
 }
 
 impl From<Polyline> for FlattenedPath {

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -154,7 +154,7 @@ impl PathTrait<Polyline> for FlattenedPath {
     /// Append another path to this one.
     ///
     /// The underlying polylines are joined, and metadata is merged
-    /// (currently first path's metadata wins).
+    /// Metadata is merged via [`PathMetadata::merge`].
     fn join(&mut self, other: &FlattenedPath, epsilon: f64) {
         self.data.join(&other.data, epsilon);
         self.metadata.merge(&other.metadata);

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -386,6 +386,65 @@ mod tests {
         );
     }
 
+    // ==================== join tests ====================
+
+    #[test]
+    fn test_polyline_join_coincident_skips_duplicate() {
+        // When endpoints are coincident, the duplicate point should be skipped
+        let mut a = Polyline::new(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+        let b = Polyline::new(vec![Point::new(10.0, 0.0), Point::new(20.0, 0.0)]);
+
+        a.join(&b, 1e-10);
+
+        assert_eq!(a.points().len(), 3);
+        assert_eq!(a.points()[0], Point::new(0.0, 0.0));
+        assert_eq!(a.points()[1], Point::new(10.0, 0.0));
+        assert_eq!(a.points()[2], Point::new(20.0, 0.0));
+    }
+
+    #[test]
+    fn test_polyline_join_gap_keeps_both_points() {
+        // When endpoints have a gap, both points should be kept (implicit bridge)
+        let mut a = Polyline::new(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+        let b = Polyline::new(vec![Point::new(10.0, 5.0), Point::new(20.0, 5.0)]);
+
+        a.join(&b, 1e-10);
+
+        assert_eq!(a.points().len(), 4);
+        assert_eq!(a.points()[1], Point::new(10.0, 0.0));
+        assert_eq!(a.points()[2], Point::new(10.0, 5.0));
+    }
+
+    #[test]
+    fn test_polyline_join_empty_other() {
+        let mut a = Polyline::new(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+        let b = Polyline::new(vec![]);
+
+        a.join(&b, 1e-10);
+
+        assert_eq!(a.points().len(), 2);
+    }
+
+    #[test]
+    fn test_flattenedpath_join_coincident() {
+        let mut a = FlattenedPath::from(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+        let b = FlattenedPath::from(vec![Point::new(10.0, 0.0), Point::new(20.0, 0.0)]);
+
+        a.join(&b, 1e-10);
+
+        assert_eq!(a.data.points().len(), 3);
+    }
+
+    #[test]
+    fn test_flattenedpath_join_gap() {
+        let mut a = FlattenedPath::from(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+        let b = FlattenedPath::from(vec![Point::new(10.0, 5.0), Point::new(20.0, 5.0)]);
+
+        a.join(&b, 1e-10);
+
+        assert_eq!(a.data.points().len(), 4);
+    }
+
     #[test]
     fn test_polyline_is_point() {
         let mut p = Polyline::from_iter([(0., 0.)]);

--- a/crates/vsvg/src/path/metadata.rs
+++ b/crates/vsvg/src/path/metadata.rs
@@ -14,3 +14,14 @@ impl Default for PathMetadata {
         }
     }
 }
+
+impl PathMetadata {
+    /// Merge another metadata into this one.
+    ///
+    /// Currently: the first one wins (self-unchanged).
+    //TODO: metadata should probably have `Option`, so the merge can be smart.
+    pub fn merge(&mut self, _other: &PathMetadata) {
+        // For now, keep self's values (first path wins)
+        // Future enhancement: if self.color.is_none() { self.color = other.color; }
+    }
+}

--- a/crates/vsvg/src/path/mod.rs
+++ b/crates/vsvg/src/path/mod.rs
@@ -15,6 +15,9 @@ pub use point::Point;
 
 pub const DEFAULT_TOLERANCE: f64 = 0.05;
 
+/// Epsilon for considering two points as coincident.
+pub const EPSILON: f64 = 1e-10;
+
 pub trait PathDataTrait:
     Transforms + SvgPathWriter + Default + Clone + PartialEq + std::fmt::Debug
 {
@@ -23,6 +26,14 @@ pub trait PathDataTrait:
     fn end(&self) -> Option<Point>;
     fn is_point(&self) -> bool;
     fn flip(&mut self);
+
+    /// Returns true if the path is closed (start ≈ end within [`EPSILON`]).
+    fn is_closed(&self) -> bool {
+        match (self.start(), self.end()) {
+            (Some(start), Some(end)) => start.distance(&end) < EPSILON,
+            _ => false,
+        }
+    }
 }
 
 pub trait PathTrait<D: PathDataTrait>: Transforms + Clone + PartialEq + std::fmt::Debug {

--- a/crates/vsvg/src/path/mod.rs
+++ b/crates/vsvg/src/path/mod.rs
@@ -15,9 +15,6 @@ pub use point::Point;
 
 pub const DEFAULT_TOLERANCE: f64 = 0.05;
 
-/// Epsilon for considering two points as coincident.
-pub const EPSILON: f64 = 1e-10;
-
 pub trait PathDataTrait:
     Transforms + SvgPathWriter + Default + Clone + PartialEq + std::fmt::Debug
 {
@@ -27,10 +24,10 @@ pub trait PathDataTrait:
     fn is_point(&self) -> bool;
     fn flip(&mut self);
 
-    /// Returns true if the path is closed (start ≈ end within [`EPSILON`]).
+    /// Returns true if the path is closed (start ≈ end within [`crate::SAME_POINT_EPSILON`]).
     fn is_closed(&self) -> bool {
         match (self.start(), self.end()) {
-            (Some(start), Some(end)) => start.distance(&end) < EPSILON,
+            (Some(start), Some(end)) => start.distance(&end) < crate::SAME_POINT_EPSILON,
             _ => false,
         }
     }

--- a/crates/vsvg/src/path/mod.rs
+++ b/crates/vsvg/src/path/mod.rs
@@ -58,10 +58,18 @@ pub trait PathTrait<D: PathDataTrait>: Transforms + Clone + PartialEq + std::fmt
 
     /// Append another path to this one.
     ///
-    /// If the endpoint of `self` and the start of `other` are within `epsilon`,
-    /// the duplicate point is skipped (for polylines) or `MoveTo` is converted
-    /// to `LineTo` (for `BezPath`s) to create a continuous path.
+    /// If the endpoint of `self` and the start of `other` are within `epsilon`, the duplicate point
+    /// is skipped (for polylines) or `MoveTo` is converted to `LineTo` (for `BezPath`s) to create a
+    /// continuous path.
     ///
     /// Metadata is merged (currently first path's metadata wins).
     fn join(&mut self, other: &Self, epsilon: f64);
+
+    /// Split a compound path into its individual subpaths.
+    ///
+    /// For `BezPath`-based paths, each `MoveTo` element starts a new subpath. For polyline-based
+    /// paths, this returns the path unchanged (polylines cannot represent compound paths).
+    ///
+    /// Metadata is cloned to all resulting paths.
+    fn split(self) -> Vec<Self>;
 }

--- a/crates/vsvg/src/path/mod.rs
+++ b/crates/vsvg/src/path/mod.rs
@@ -55,4 +55,13 @@ pub trait PathTrait<D: PathDataTrait>: Transforms + Clone + PartialEq + std::fmt
 
     fn metadata(&self) -> &PathMetadata;
     fn metadata_mut(&mut self) -> &mut PathMetadata;
+
+    /// Append another path to this one.
+    ///
+    /// If the endpoint of `self` and the start of `other` are within `epsilon`,
+    /// the duplicate point is skipped (for polylines) or `MoveTo` is converted
+    /// to `LineTo` (for `BezPath`s) to create a continuous path.
+    ///
+    /// Metadata is merged (currently first path's metadata wins).
+    fn join(&mut self, other: &Self, epsilon: f64);
 }

--- a/crates/vsvg/src/path/mod.rs
+++ b/crates/vsvg/src/path/mod.rs
@@ -62,7 +62,8 @@ pub trait PathTrait<D: PathDataTrait>: Transforms + Clone + PartialEq + std::fmt
     /// is skipped (for polylines) or `MoveTo` is converted to `LineTo` (for `BezPath`s) to create a
     /// continuous path.
     ///
-    /// Metadata is merged (currently first path's metadata wins).
+    /// Metadata is merged via [`PathMetadata::merge`] (compatible values are kept, conflicts
+    /// become `None`).
     fn join(&mut self, other: &Self, epsilon: f64);
 
     /// Split a compound path into its individual subpaths.

--- a/crates/vsvg/src/path/mod.rs
+++ b/crates/vsvg/src/path/mod.rs
@@ -53,11 +53,12 @@ pub trait PathTrait<D: PathDataTrait>: Transforms + Clone + PartialEq + std::fmt
     fn metadata(&self) -> &PathMetadata;
     fn metadata_mut(&mut self) -> &mut PathMetadata;
 
-    /// Append another path to this one.
+    /// Append another path to this one, creating a continuous path.
     ///
-    /// If the endpoint of `self` and the start of `other` are within `epsilon`, the duplicate point
-    /// is skipped (for polylines) or `MoveTo` is converted to `LineTo` (for `BezPath`s) to create a
-    /// continuous path.
+    /// If `self`'s endpoint and `other`'s start are within `epsilon`, the duplicate junction
+    /// point is skipped (polylines) or the `MoveTo` is dropped (`BezPath`s). Otherwise the gap
+    /// is bridged: polylines keep both points (implicit segment), `BezPath`s convert `MoveTo`
+    /// to `LineTo`.
     ///
     /// Metadata is merged via [`PathMetadata::merge`] (compatible values are kept, conflicts
     /// become `None`).

--- a/crates/vsvg/src/path/path.rs
+++ b/crates/vsvg/src/path/path.rs
@@ -251,6 +251,85 @@ impl Path {
         self.data = new_bezpath;
         self
     }
+
+    /// Append another path to this one.
+    ///
+    /// If the endpoint of `self` and the start of `other` are within `epsilon`,
+    /// the initial `MoveTo` of `other` is converted to `LineTo` to create a continuous path.
+    /// Otherwise, the `MoveTo` is kept, creating a compound path with multiple subpaths.
+    ///
+    /// Metadata is merged (currently first path's metadata wins).
+    pub fn join(&mut self, other: &Path, epsilon: f64) {
+        let dominated = match (self.data.end(), other.data.start()) {
+            (Some(end), Some(start)) => end.distance(&start) < epsilon,
+            _ => false,
+        };
+
+        for (i, el) in other.data.elements().iter().enumerate() {
+            if i == 0 {
+                match el {
+                    PathEl::MoveTo(pt) if dominated => {
+                        self.data.push(PathEl::LineTo(*pt));
+                    }
+                    _ => self.data.push(*el),
+                }
+            } else {
+                self.data.push(*el);
+            }
+        }
+
+        self.metadata.merge(&other.metadata);
+    }
+
+    /// Split a compound path into its individual subpaths.
+    ///
+    /// Each `MoveTo` element starts a new subpath. Metadata is cloned to all
+    /// resulting paths.
+    ///
+    /// Returns a single-element `Vec` if the path has only one subpath.
+    /// Returns an empty `Vec` if the path is empty.
+    ///
+    /// This is useful before [`Layer::join_paths`](crate::Layer::join_paths) to
+    /// maximize optimization opportunities, since `join_paths` only considers
+    /// the start/end points of each path, not internal subpath endpoints.
+    #[must_use]
+    pub fn split(self) -> Vec<Self> {
+        let elements = self.data.elements();
+        if elements.is_empty() {
+            return vec![];
+        }
+
+        let mut result = Vec::new();
+        let mut current = BezPath::new();
+
+        for el in elements {
+            match el {
+                PathEl::MoveTo(pt) => {
+                    // Save current path if non-empty and start new one
+                    if !current.elements().is_empty() {
+                        result.push(Path {
+                            data: std::mem::take(&mut current),
+                            metadata: self.metadata.clone(),
+                        });
+                    }
+                    current.push(PathEl::MoveTo(*pt));
+                }
+                _ => {
+                    current.push(*el);
+                }
+            }
+        }
+
+        // Don't forget the last subpath
+        if !current.elements().is_empty() {
+            result.push(Path {
+                data: current,
+                metadata: self.metadata,
+            });
+        }
+
+        result
+    }
 }
 
 impl<T: IntoBezPath> From<T> for Path {
@@ -320,5 +399,72 @@ mod test {
 
         let path = Path::from_svg("M 10,0 L 10,0").unwrap();
         assert!(path.data.is_point());
+    }
+
+    #[test]
+    fn test_path_split_simple() {
+        // Single subpath - returns vec with one element
+        let path = Path::from_svg("M 0,0 L 10,10 L 20,0").unwrap();
+        let parts = path.split();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].data.elements().len(), 3); // MoveTo + 2 LineTo
+    }
+
+    #[test]
+    fn test_path_split_compound() {
+        // Two subpaths
+        let path = Path::from_svg("M 0,0 L 10,10 M 50,50 L 60,60").unwrap();
+        let parts = path.split();
+        assert_eq!(parts.len(), 2);
+
+        // First subpath: M 0,0 L 10,10
+        assert_eq!(parts[0].data.elements().len(), 2);
+        assert_eq!(parts[0].data.start(), Some(Point::new(0.0, 0.0)));
+        assert_eq!(parts[0].data.end(), Some(Point::new(10.0, 10.0)));
+
+        // Second subpath: M 50,50 L 60,60
+        assert_eq!(parts[1].data.elements().len(), 2);
+        assert_eq!(parts[1].data.start(), Some(Point::new(50.0, 50.0)));
+        assert_eq!(parts[1].data.end(), Some(Point::new(60.0, 60.0)));
+    }
+
+    #[test]
+    fn test_path_split_three_subpaths() {
+        let path = Path::from_svg("M 0,0 L 10,0 M 20,0 L 30,0 M 40,0 L 50,0").unwrap();
+        let parts = path.split();
+        assert_eq!(parts.len(), 3);
+    }
+
+    #[test]
+    fn test_path_split_empty() {
+        let path = Path::default();
+        let parts = path.split();
+        assert!(parts.is_empty());
+    }
+
+    #[test]
+    fn test_path_split_with_close() {
+        // Closed subpath followed by open subpath
+        let path = Path::from_svg("M 0,0 L 10,0 L 10,10 Z M 50,50 L 60,60").unwrap();
+        let parts = path.split();
+        assert_eq!(parts.len(), 2);
+
+        // First is closed (has ClosePath)
+        assert!(
+            parts[0]
+                .data
+                .elements()
+                .iter()
+                .any(|el| matches!(el, PathEl::ClosePath))
+        );
+
+        // Second is open
+        assert!(
+            !parts[1]
+                .data
+                .elements()
+                .iter()
+                .any(|el| matches!(el, PathEl::ClosePath))
+        );
     }
 }

--- a/crates/vsvg/src/path/path.rs
+++ b/crates/vsvg/src/path/path.rs
@@ -107,7 +107,7 @@ impl PathTrait<BezPath> for Path {
     /// the initial `MoveTo` of `other` is converted to `LineTo` to create a continuous path.
     /// Otherwise, the `MoveTo` is kept, creating a compound path with multiple subpaths.
     ///
-    /// Metadata is merged (currently first path's metadata wins).
+    /// Metadata is merged via [`PathMetadata::merge`].
     fn join(&mut self, other: &Path, epsilon: f64) {
         let should_connect = match (self.data.end(), other.data.start()) {
             (Some(end), Some(start)) => end.distance(&start) < epsilon,
@@ -130,6 +130,9 @@ impl PathTrait<BezPath> for Path {
         self.metadata.merge(&other.metadata);
     }
 
+    /// Split a compound path into its individual paths.
+    ///
+    /// The returned paths always consist of a single, non-compound path.
     fn split(self) -> Vec<Self> {
         let elements = self.data.elements();
         if elements.is_empty() {
@@ -157,7 +160,7 @@ impl PathTrait<BezPath> for Path {
             }
         }
 
-        // Don't forget the last subpath
+        // Remember the last subpath
         if !current.elements().is_empty() {
             result.push(Path {
                 data: current,

--- a/crates/vsvg/src/path/path.rs
+++ b/crates/vsvg/src/path/path.rs
@@ -103,13 +103,13 @@ impl PathTrait<BezPath> for Path {
 
     /// Append another path to this one.
     ///
-    /// If the endpoint of `self` and the start of `other` are within `epsilon`,
-    /// the initial `MoveTo` of `other` is converted to `LineTo` to create a continuous path.
-    /// Otherwise, the `MoveTo` is kept, creating a compound path with multiple subpaths.
+    /// The initial `MoveTo` of `other` is either dropped (if within `epsilon` of `self`'s
+    /// endpoint, avoiding a degenerate segment) or converted to `LineTo` (bridging the gap).
     ///
     /// Metadata is merged via [`PathMetadata::merge`].
     fn join(&mut self, other: &Path, epsilon: f64) {
-        let should_connect = match (self.data.end(), other.data.start()) {
+        let self_is_empty = self.data.elements().is_empty();
+        let is_coincident = match (self.data.end(), other.data.start()) {
             (Some(end), Some(start)) => end.distance(&start) < epsilon,
             _ => false,
         };
@@ -117,7 +117,16 @@ impl PathTrait<BezPath> for Path {
         for (i, el) in other.data.elements().iter().enumerate() {
             if i == 0 {
                 match el {
-                    PathEl::MoveTo(pt) if should_connect => {
+                    PathEl::MoveTo(_) if is_coincident => {
+                        // Skip: points are coincident, no segment needed
+                    }
+
+                    PathEl::MoveTo(pt) if self_is_empty => {
+                        // Keep MoveTo: BezPath must start with MoveTo
+                        self.data.push(PathEl::MoveTo(*pt));
+                    }
+
+                    PathEl::MoveTo(pt) => {
                         self.data.push(PathEl::LineTo(*pt));
                     }
                     _ => self.data.push(*el),
@@ -431,6 +440,58 @@ mod test {
         let path = Path::default();
         let parts = path.split();
         assert!(parts.is_empty());
+    }
+
+    // ==================== join tests ====================
+
+    #[test]
+    fn test_path_join_coincident_drops_moveto() {
+        // When endpoints are coincident, MoveTo should be dropped (no degenerate LineTo)
+        let mut a = Path::from_svg("M 0,0 L 10,0").unwrap();
+        let b = Path::from_svg("M 10,0 L 20,0").unwrap();
+
+        a.join(&b, 1e-10);
+
+        // M 0,0 L 10,0 L 20,0 — 3 elements, no degenerate segment
+        assert_eq!(a.data.elements().len(), 3);
+        assert_eq!(a.data.start(), Some(Point::new(0.0, 0.0)));
+        assert_eq!(a.data.end(), Some(Point::new(20.0, 0.0)));
+    }
+
+    #[test]
+    fn test_path_join_gap_inserts_lineto() {
+        // When endpoints have a gap, MoveTo should become LineTo to bridge it
+        let mut a = Path::from_svg("M 0,0 L 10,0").unwrap();
+        let b = Path::from_svg("M 10,5 L 20,5").unwrap();
+
+        a.join(&b, 1e-10);
+
+        // M 0,0 L 10,0 L 10,5 L 20,5 — 4 elements with bridging LineTo
+        assert_eq!(a.data.elements().len(), 4);
+        assert!(matches!(a.data.elements()[2], PathEl::LineTo(_)));
+        assert_eq!(a.data.end(), Some(Point::new(20.0, 5.0)));
+    }
+
+    #[test]
+    fn test_path_join_empty_other() {
+        let mut a = Path::from_svg("M 0,0 L 10,0").unwrap();
+        let b = Path::default();
+
+        a.join(&b, 1e-10);
+
+        assert_eq!(a.data.elements().len(), 2);
+    }
+
+    #[test]
+    fn test_path_join_empty_self() {
+        let mut a = Path::default();
+        let b = Path::from_svg("M 10,0 L 20,0").unwrap();
+
+        a.join(&b, 1e-10);
+
+        // Empty self keeps MoveTo: M 10,0 L 20,0
+        assert_eq!(a.data.elements().len(), 2);
+        assert!(matches!(a.data.elements()[0], PathEl::MoveTo(_)));
     }
 
     #[test]

--- a/crates/whiskers/src/runner/optimization.rs
+++ b/crates/whiskers/src/runner/optimization.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use std::fmt::{Display, Formatter};
-use vsvg::DocumentTrait;
+use vsvg::{DocumentTrait, LayerTrait};
 use whiskers_widgets::collapsing_header;
 
 /// Options controlling the optimization pass before saving to files.


### PR DESCRIPTION
This PR adds support for joining to paths, and path merging optimisation to layers. This is only the low-level machinery. It is not exposed yet to either the CLI or whiskers.

### Constants
  - `SAME_POINT_EPSILON: f64 = 1e-10` — point coincidence threshold (crate-level, in `vsvg::lib.rs`)

### `Polyline`
  - `join(&mut self, other: &Polyline, epsilon: f64)` — append polyline, skipping duplicate junction point

### `PathDataTrait`
  - `is_closed(&self) -> bool` — checks if start ≈ end within `SAME_POINT_EPSILON`

### `PathTrait`
  - `join(&mut self, other: &Self, epsilon: f64)` — append path, merge at coincident endpoints
  - `split(self) -> Vec<Self>` — split compound paths at `MoveTo` boundaries

### `PathMetadata`
  - `merge(&mut self, other: &PathMetadata)` — merge metadata (first wins)

### `LayerTrait`
  - `join_paths(&mut self, tolerance: f64, flip: bool)` — join adjacent paths within tolerance
  - `explode(&mut self)` — split all compound paths into subpaths

### Free Functions (`vsvg::optimization`)
  - `sort_paths<P, D>(paths: &mut Vec<P>, flip: bool)`
  - `sort_paths_with_builder<P, D>(paths: &mut Vec<P>, builder: IndexBuilder)`
  - `join_paths<P, D>(paths: &mut Vec<P>, tolerance: f64, flip: bool)`

### Changed
  - `LayerTrait::sort`/`sort_with_builder` now delegate to free functions in `optimization`

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #188 
- <kbd>&nbsp;5&nbsp;</kbd> #191 
- <kbd>&nbsp;4&nbsp;</kbd> #187 
- <kbd>&nbsp;3&nbsp;</kbd> #186 
- <kbd>&nbsp;2&nbsp;</kbd> #184 
- <kbd>&nbsp;1&nbsp;</kbd> #183 👈 
<!-- GitButler Footer Boundary Bottom -->