### PR TITLE
Add `.buffer()` to `Path` and `FlattenedPath`

### DIFF
--- a/crates/vsvg/Cargo.toml
+++ b/crates/vsvg/Cargo.toml
@@ -36,8 +36,10 @@ usvg.workspace = true
 whiskers-widgets = { workspace = true, optional = true }
 egui = { workspace = true, optional = true }
 
+# geo is required for polygon operations
+geo.workspace = true
+
 # optional dependencies, mainly for Point interop.
-geo = { workspace = true, optional = true }
 glam = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -48,7 +50,7 @@ rand_chacha.workspace = true
 criterion.workspace = true
 
 [features]
-default = ["geo"]
+default = []
 puffin = ["dep:puffin", "profiling/profile-with-puffin"]
 whiskers-widgets = ["dep:whiskers-widgets", "dep:egui"]
 egui = ["dep:egui"]

--- a/crates/vsvg/src/lib.rs
+++ b/crates/vsvg/src/lib.rs
@@ -48,7 +48,6 @@ pub use unit::*;
 pub mod exports {
     #[cfg(feature = "egui")]
     pub use ::egui;
-    #[cfg(feature = "geo")]
     pub use ::geo;
     pub use ::kurbo;
     #[cfg(feature = "puffin")]

--- a/crates/vsvg/src/optimization.rs
+++ b/crates/vsvg/src/optimization.rs
@@ -62,6 +62,7 @@ where
 ///
 /// Unlike [`sort_paths`] which reorders paths, `join_paths` concatenates
 /// them, reducing the total path count.
+#[allow(clippy::cognitive_complexity)]
 pub fn join_paths<P, D>(paths: &mut Vec<P>, tolerance: f64, flip: bool)
 where
     P: PathTrait<D>,
@@ -81,54 +82,94 @@ where
     };
     let mut current = first_item.path.clone();
 
-    // Greedy chain building
-    loop {
-        let Some(current_end) = current.end() else {
-            result.push(current);
-            match index.pop_first() {
-                Some(item) => current = item.path.clone(),
-                None => break,
-            }
-            continue;
-        };
+    // Greedy chain building with append and prepend phases (like vpype)
+    'outer: loop {
+        // Append phase: extend from current end
+        loop {
+            let Some(current_end) = current.end() else {
+                break;
+            };
 
-        // Find nearest path within tolerance
-        if let Some((item, reversed)) = index.pop_nearest(&current_end) {
-            let candidate_start = if reversed {
+            let Some((item, reversed)) = index.pop_nearest(&current_end) else {
+                break;
+            };
+
+            let candidate_pt = if reversed {
                 item.end.unwrap_or(current_end)
             } else {
                 item.start.unwrap_or(current_end)
             };
 
-            if current_end.distance(&candidate_start) <= tolerance {
-                // Join this path
+            if current_end.distance(&candidate_pt) <= tolerance {
                 let mut next = item.path.clone();
                 if reversed {
                     next.data_mut().flip();
                 }
-                // Use small EPSILON for duplicate detection, not tolerance
-                // (tolerance is for deciding IF paths should join, EPSILON is for skipping
-                // true duplicate points at the junction)
                 current.join(&next, SAME_POINT_EPSILON);
-                // Continue trying to extend
             } else {
-                // Too far, start new chain
-                result.push(current);
-                current = item.path.clone();
+                // Candidate was too far - save current, use candidate as new current
+                let mut next = item.path.clone();
                 if reversed {
-                    current.data_mut().flip();
+                    next.data_mut().flip();
                 }
+                result.push(current);
+                current = next;
+                continue 'outer; // Restart both phases with new current
             }
+        }
+
+        // Prepend phase: extend from current start
+        loop {
+            let Some(current_start) = current.start() else {
+                break;
+            };
+
+            let Some((item, reversed)) = index.pop_nearest(&current_start) else {
+                break;
+            };
+
+            // Get the point that the spatial index actually matched (same logic as append phase).
+            // The flip decision below will ensure this point ends up as the candidate's END,
+            // which is what we need for prepending (candidate's END connects to current's START).
+            let candidate_pt = if reversed {
+                item.end.unwrap_or(current_start)
+            } else {
+                item.start.unwrap_or(current_start)
+            };
+
+            if current_start.distance(&candidate_pt) <= tolerance {
+                let mut prev = item.path.clone();
+                // For prepend: flip if we matched START (reversed=false)
+                // so that original START becomes new END (connection point)
+                if !reversed {
+                    prev.data_mut().flip();
+                }
+                prev.join(&current, SAME_POINT_EPSILON);
+                current = prev;
+            } else {
+                // Too far - save current, use candidate as new current
+                // Keep the candidate in its natural orientation for now
+                let mut next = item.path.clone();
+                // Note: for the "else" branch, we're starting a new chain,
+                // so we orient the path based on what was matched
+                if reversed {
+                    next.data_mut().flip();
+                }
+                result.push(current);
+                current = next;
+                continue 'outer; // Restart both phases with new current
+            }
+        }
+
+        // Both phases done - save current chain
+        result.push(current);
+
+        // Start new chain if index not empty
+        if let Some(next_item) = index.pop_first() {
+            current = next_item.path.clone();
         } else {
-            // No more paths in index
-            result.push(current);
             break;
         }
-    }
-
-    // Add remaining paths from index (shouldn't happen normally)
-    while let Some(item) = index.pop_first() {
-        result.push(item.path.clone());
     }
 
     *paths = result;
@@ -383,10 +424,126 @@ mod tests {
     }
 
     #[test]
+    fn test_join_paths_prepend() {
+        // Test that prepending works: B's end connects to A's start
+        let mut layer = FlattenedLayer::default();
+
+        // A: (10, 0) -> (20, 0) - will be popped first (paths are reversed on insert)
+        // B: (0, 0) -> (10, 0) - B's end matches A's start
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+        ]));
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(10.0, 0.0),
+            Point::new(20.0, 0.0),
+        ]));
+
+        // With flip=true, should join via prepending
+        layer.join_paths(0.1, true);
+
+        assert_eq!(layer.paths.len(), 1, "Should join into single path");
+        let points = layer.paths[0].data.points();
+        assert_eq!(points.len(), 3, "Should have 3 points");
+
+        // A is popped first (last pushed), then B is prepended via the prepend phase.
+        // Result: (0, 0) -> (10, 0) -> (20, 0)
+        assert_eq!(points[0], Point::new(0.0, 0.0));
+        assert_eq!(points[1], Point::new(10.0, 0.0));
+        assert_eq!(points[2], Point::new(20.0, 0.0));
+    }
+
+    #[test]
+    fn test_join_paths_prepend_only() {
+        // Scenario where ONLY prepending can join, not appending
+        // A is processed first but nothing connects to A's end
+        // B's end connects to A's start
+        let mut layer = FlattenedLayer::default();
+
+        // A: (50, 0) -> (100, 0)
+        // B: (0, 0) -> (50, 0) - B's end matches A's start, nothing matches A's end
+        // Paths are reversed on insert, so A will be popped first
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(0.0, 0.0),
+            Point::new(50.0, 0.0),
+        ]));
+        layer.paths.push(FlattenedPath::from(vec![
+            Point::new(50.0, 0.0),
+            Point::new(100.0, 0.0),
+        ]));
+
+        layer.join_paths(0.1, true);
+
+        assert_eq!(
+            layer.paths.len(),
+            1,
+            "Should join into single path via prepend"
+        );
+        assert_eq!(layer.paths[0].data.points().len(), 3);
+    }
+
+    #[test]
     fn test_join_paths_empty_layer() {
         let mut layer = FlattenedLayer::default();
         layer.join_paths(1.0, true);
         assert_eq!(layer.paths.len(), 0);
+    }
+
+    #[test]
+    fn test_join_paths_angled_hatch_lines() {
+        // Simulates hatch lines at ~14° angle in a square
+        // At this angle, lines clip to the square boundary at different points
+        // This tests that the zigzag joining works correctly
+        let mut layer = FlattenedLayer::default();
+
+        // Approximate 14° hatch lines in a 100x100 square
+        // The lines are nearly horizontal but endpoints are staggered
+        // Spacing ~10 units vertically
+        let lines = vec![
+            // (start_x, start_y) -> (end_x, end_y)
+            ((0.0, 5.0), (80.0, 25.0)),
+            ((0.0, 15.0), (100.0, 40.0)),
+            ((0.0, 25.0), (100.0, 50.0)),
+            ((0.0, 35.0), (100.0, 60.0)),
+            ((0.0, 45.0), (100.0, 70.0)),
+            ((20.0, 55.0), (100.0, 75.0)),
+        ];
+
+        for ((x1, y1), (x2, y2)) in &lines {
+            layer.paths.push(FlattenedPath::from(vec![
+                Point::new(*x1, *y1),
+                Point::new(*x2, *y2),
+            ]));
+        }
+
+        let original_count = layer.paths.len();
+
+        // Tolerance of 50 should allow zigzag connections (endpoints are ~25-30 apart)
+        layer.join_paths(50.0, true);
+
+        // Should join into fewer paths (ideally 1 or 2)
+        assert!(
+            layer.paths.len() < original_count,
+            "Should join at least some paths: had {}, now {}",
+            original_count,
+            layer.paths.len()
+        );
+
+        // Print results for debugging
+        println!(
+            "Angled hatch: {} paths -> {} paths",
+            original_count,
+            layer.paths.len()
+        );
+        for (i, path) in layer.paths.iter().enumerate() {
+            println!(
+                "  Path {}: {} points, start={:?}, end={:?}",
+                i,
+                path.data.points().len(),
+                path.data.start(),
+                path.data.end()
+            );
+        }
     }
 
     #[test]

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -64,6 +64,101 @@ impl Polyline {
 
         self.0.extend(other.0.iter().skip(skip).copied());
     }
+
+    /// Convert to `geo::Polygon`.
+    ///
+    /// Since a polyline represents a single ring (no holes), only a subset of
+    /// [`super::ToGeoPolygonError`] variants can be returned:
+    ///
+    /// # Errors
+    /// - [`super::ToGeoPolygonError::ExteriorNotClosed`] if the polyline is not closed
+    /// - [`super::ToGeoPolygonError::ExteriorTooFewPoints`] if fewer than 3 distinct points
+    /// - [`super::ToGeoPolygonError::InvalidPolygon`] if geo validation fails (e.g., self-intersection)
+    pub fn to_geo_polygon(&self) -> Result<geo::Polygon<f64>, super::ToGeoPolygonError> {
+        use super::ToGeoPolygonError;
+        use geo::algorithm::validation::Validation;
+
+        let points = self.points();
+
+        // Need at least 3 points for a valid polygon (triangle)
+        if points.len() < 3 {
+            return Err(ToGeoPolygonError::ExteriorTooFewPoints);
+        }
+
+        // Must be closed
+        if !self.is_closed() {
+            return Err(ToGeoPolygonError::ExteriorNotClosed);
+        }
+
+        // Convert points to geo::Coord
+        let coords: Vec<geo::Coord<f64>> = points
+            .iter()
+            .map(|p| geo::Coord { x: p.x(), y: p.y() })
+            .collect();
+
+        // Create LineString (geo requires the ring to be explicitly closed)
+        let exterior = geo::LineString::new(coords);
+        let polygon = geo::Polygon::new(exterior, vec![]);
+
+        // Validate the resulting polygon
+        polygon.check_validation()?;
+
+        Ok(polygon)
+    }
+
+    /// Buffer (expand or shrink) this closed polyline.
+    ///
+    /// - Positive distance = expand outward
+    /// - Negative distance = shrink inward
+    ///
+    /// May return multiple paths if the shape splits, or empty if fully eroded.
+    ///
+    /// # Errors
+    /// See [`Polyline::to_geo_polygon`] — only `ExteriorNotClosed`, `ExteriorTooFewPoints`,
+    /// and `InvalidPolygon` variants are possible.
+    pub fn buffer(
+        &self,
+        distance: impl Into<crate::Length>,
+    ) -> Result<Vec<FlattenedPath>, super::ToGeoPolygonError> {
+        use geo::Buffer;
+
+        let polygon = self.to_geo_polygon()?;
+        let distance_f64: f64 = distance.into().into();
+        let multi_polygon = polygon.buffer(distance_f64);
+
+        Ok(multi_polygon_to_flattened_paths(&multi_polygon))
+    }
+}
+
+/// Convert `geo::MultiPolygon` to `Vec<FlattenedPath>`.
+fn multi_polygon_to_flattened_paths(mp: &geo::MultiPolygon<f64>) -> Vec<FlattenedPath> {
+    mp.0.iter().flat_map(polygon_to_flattened_paths).collect()
+}
+
+/// Convert `geo::Polygon` to `Vec<FlattenedPath>`.
+fn polygon_to_flattened_paths(polygon: &geo::Polygon<f64>) -> Vec<FlattenedPath> {
+    let mut result = Vec::new();
+
+    // Exterior ring
+    let exterior_points: Vec<Point> = polygon
+        .exterior()
+        .0
+        .iter()
+        .map(|c| Point::new(c.x, c.y))
+        .collect();
+    if exterior_points.len() >= 3 {
+        result.push(FlattenedPath::from(Polyline::new(exterior_points)));
+    }
+
+    // Interior rings (holes) as separate paths
+    for interior in polygon.interiors() {
+        let hole_points: Vec<Point> = interior.0.iter().map(|c| Point::new(c.x, c.y)).collect();
+        if hole_points.len() >= 3 {
+            result.push(FlattenedPath::from(Polyline::new(hole_points)));
+        }
+    }
+
+    result
 }
 
 impl<P: Into<Point>> FromIterator<P> for Polyline {
@@ -328,6 +423,45 @@ impl FlattenedPath {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ToGeoPolygonError;
+
+    #[test]
+    fn test_polyline_to_geo_polygon_triangle() {
+        let polyline = Polyline::new(vec![
+            Point::new(0.0, 0.0),
+            Point::new(1.0, 0.0),
+            Point::new(0.5, 1.0),
+            Point::new(0.0, 0.0), // Closed
+        ]);
+
+        let polygon = polyline.to_geo_polygon().expect("should convert");
+        assert_eq!(polygon.exterior().0.len(), 4); // 3 points + closing point
+        assert!(polygon.interiors().is_empty());
+    }
+
+    #[test]
+    fn test_polyline_to_geo_polygon_not_closed() {
+        let polyline = Polyline::new(vec![
+            Point::new(0.0, 0.0),
+            Point::new(1.0, 0.0),
+            Point::new(0.5, 1.0),
+            // Not closed
+        ]);
+
+        let result = polyline.to_geo_polygon();
+        assert!(matches!(result, Err(ToGeoPolygonError::ExteriorNotClosed)));
+    }
+
+    #[test]
+    fn test_polyline_to_geo_polygon_too_few_points() {
+        let polyline = Polyline::new(vec![Point::new(0.0, 0.0), Point::new(1.0, 0.0)]);
+
+        let result = polyline.to_geo_polygon();
+        assert!(matches!(
+            result,
+            Err(ToGeoPolygonError::ExteriorTooFewPoints)
+        ));
+    }
 
     #[test]
     fn test_flattened_path_bounds() {

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -464,6 +464,63 @@ mod tests {
     }
 
     #[test]
+    fn test_polyline_buffer_shrink_square() {
+        let polyline = Polyline::new(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            Point::new(10.0, 10.0),
+            Point::new(0.0, 10.0),
+            Point::new(0.0, 0.0),
+        ]);
+        let result = polyline.buffer(-1.0).expect("should buffer");
+        assert_eq!(result.len(), 1);
+
+        // 10x10 shrunk by 1 on each side => ~8x8
+        let bounds = result[0].bounds();
+        assert!((bounds.width() - 8.0).abs() < 0.5);
+        assert!((bounds.height() - 8.0).abs() < 0.5);
+    }
+
+    #[test]
+    fn test_polyline_buffer_expand_square() {
+        let polyline = Polyline::new(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            Point::new(10.0, 10.0),
+            Point::new(0.0, 10.0),
+            Point::new(0.0, 0.0),
+        ]);
+        let result = polyline.buffer(1.0).expect("should buffer");
+        assert!(!result.is_empty());
+        let bounds = result[0].bounds();
+        assert!(bounds.width() > 10.0);
+        assert!(bounds.height() > 10.0);
+    }
+
+    #[test]
+    fn test_polyline_buffer_completely_erodes() {
+        let polyline = Polyline::new(vec![
+            Point::new(0.0, 0.0),
+            Point::new(2.0, 0.0),
+            Point::new(2.0, 2.0),
+            Point::new(0.0, 2.0),
+            Point::new(0.0, 0.0),
+        ]);
+        let result = polyline.buffer(-2.0).expect("should buffer");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_polyline_buffer_open_polyline_error() {
+        let polyline = Polyline::new(vec![
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            Point::new(10.0, 10.0),
+        ]);
+        assert!(polyline.buffer(-1.0).is_err());
+    }
+
+    #[test]
     fn test_flattened_path_bounds() {
         let points = vec![
             Point::new(0.0, 0.0),

--- a/crates/vsvg/src/path/into_bezpath.rs
+++ b/crates/vsvg/src/path/into_bezpath.rs
@@ -96,7 +96,6 @@ impl IntoBezPathTolerance for Polyline {
     }
 }
 
-#[cfg(feature = "geo")]
 pub mod geo_impl {
     #[allow(clippy::wildcard_imports)]
     use super::*;
@@ -350,7 +349,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "geo")]
     mod geo_tests {
         use super::super::geo_impl::*;
         use super::*;

--- a/crates/vsvg/src/path/path.rs
+++ b/crates/vsvg/src/path/path.rs
@@ -330,6 +330,151 @@ impl Path {
         self.data = new_bezpath;
         self
     }
+
+    /// Convert path to `geo::Polygon`, flattening curves with given tolerance.
+    ///
+    /// For compound paths (multiple subpaths):
+    /// - First subpath becomes the exterior ring
+    /// - Subsequent closed subpaths become interior rings (holes)
+    /// - Unclosed interior subpaths return an error
+    ///
+    /// # Errors
+    ///
+    /// All [`super::ToGeoPolygonError`] variants are possible:
+    /// - [`super::ToGeoPolygonError::EmptyPath`] if the path has no subpaths
+    /// - [`super::ToGeoPolygonError::ExteriorNotClosed`] / [`super::ToGeoPolygonError::ExteriorTooFewPoints`] for the first subpath
+    /// - [`super::ToGeoPolygonError::InteriorNotClosed`] / [`super::ToGeoPolygonError::InteriorTooFewPoints`] for subsequent subpaths (holes)
+    /// - [`super::ToGeoPolygonError::InvalidPolygon`] if geo validation fails (e.g., self-intersection)
+    pub fn to_geo_polygon(
+        &self,
+        tolerance: f64,
+    ) -> Result<geo::Polygon<f64>, super::ToGeoPolygonError> {
+        use super::ToGeoPolygonError;
+        use geo::algorithm::validation::Validation;
+
+        // Flatten curves to polylines (one per subpath)
+        let flattened = self.flatten(tolerance);
+
+        let mut iter = flattened.into_iter();
+
+        // First subpath is exterior ring
+        let Some(exterior_polyline) = iter.next() else {
+            return Err(ToGeoPolygonError::EmptyPath);
+        };
+        let exterior_points = exterior_polyline.data.points();
+
+        if exterior_points.len() < 3 {
+            return Err(ToGeoPolygonError::ExteriorTooFewPoints);
+        }
+
+        if !exterior_polyline.data.is_closed() {
+            return Err(ToGeoPolygonError::ExteriorNotClosed);
+        }
+
+        let exterior_coords: Vec<geo::Coord<f64>> = exterior_points
+            .iter()
+            .map(|p| geo::Coord { x: p.x(), y: p.y() })
+            .collect();
+        let exterior = geo::LineString::new(exterior_coords);
+
+        // Remaining subpaths are holes (interior rings)
+        let mut interiors = Vec::new();
+        for (i, hole_path) in iter.enumerate() {
+            let hole_points = hole_path.data.points();
+
+            if hole_points.len() < 3 {
+                return Err(ToGeoPolygonError::InteriorTooFewPoints(i));
+            }
+
+            if !hole_path.data.is_closed() {
+                return Err(ToGeoPolygonError::InteriorNotClosed(i));
+            }
+
+            let hole_coords: Vec<geo::Coord<f64>> = hole_points
+                .iter()
+                .map(|p| geo::Coord { x: p.x(), y: p.y() })
+                .collect();
+            interiors.push(geo::LineString::new(hole_coords));
+        }
+
+        let polygon = geo::Polygon::new(exterior, interiors);
+
+        // Validate the resulting polygon (checks self-intersection, etc.)
+        polygon.check_validation()?;
+
+        Ok(polygon)
+    }
+
+    /// Buffer (expand or shrink) this closed path.
+    ///
+    /// - Positive distance = expand outward
+    /// - Negative distance = shrink inward
+    ///
+    /// Returns flattened paths since buffer operations work on polygons.
+    /// May return multiple paths if the shape splits, or empty if fully eroded.
+    ///
+    /// # Errors
+    /// See [`Path::to_geo_polygon`] — all [`super::ToGeoPolygonError`] variants are possible.
+    ///
+    /// # Example
+    /// ```
+    /// use vsvg::{Path, Unit};
+    /// use kurbo::Circle;
+    ///
+    /// let circle = Path::from(Circle::new((0.0, 0.0), 10.0));
+    ///
+    /// // Expand by 1 unit
+    /// let expanded = circle.buffer(1.0, 0.1).unwrap();
+    ///
+    /// // Shrink by 0.5 units (for hatching inset)
+    /// let shrunk = circle.buffer(-0.5, 0.1).unwrap();
+    /// ```
+    pub fn buffer(
+        &self,
+        distance: impl Into<crate::Length>,
+        tolerance: f64,
+    ) -> Result<Vec<FlattenedPath>, super::ToGeoPolygonError> {
+        use geo::Buffer;
+
+        let polygon = self.to_geo_polygon(tolerance)?;
+        let distance_f64: f64 = distance.into().into();
+        let multi_polygon = polygon.buffer(distance_f64);
+
+        Ok(multi_polygon_to_flattened_paths(&multi_polygon))
+    }
+}
+
+/// Convert `geo::MultiPolygon` to `Vec<FlattenedPath>`.
+fn multi_polygon_to_flattened_paths(mp: &geo::MultiPolygon<f64>) -> Vec<FlattenedPath> {
+    mp.0.iter().flat_map(polygon_to_flattened_paths).collect()
+}
+
+/// Convert `geo::Polygon` to `Vec<FlattenedPath>`.
+///
+/// Returns one path for the exterior and one for each interior (hole).
+fn polygon_to_flattened_paths(polygon: &geo::Polygon<f64>) -> Vec<FlattenedPath> {
+    let mut result = Vec::new();
+
+    // Exterior ring
+    let exterior_points: Vec<Point> = polygon
+        .exterior()
+        .0
+        .iter()
+        .map(|c| Point::new(c.x, c.y))
+        .collect();
+    if exterior_points.len() >= 3 {
+        result.push(FlattenedPath::from(Polyline::new(exterior_points)));
+    }
+
+    // Interior rings (holes) as separate paths
+    for interior in polygon.interiors() {
+        let hole_points: Vec<Point> = interior.0.iter().map(|c| Point::new(c.x, c.y)).collect();
+        if hole_points.len() >= 3 {
+            result.push(FlattenedPath::from(Polyline::new(hole_points)));
+        }
+    }
+
+    result
 }
 
 impl<T: IntoBezPath> From<T> for Path {
@@ -353,7 +498,118 @@ impl From<FlattenedPath> for Path {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ToGeoPolygonError;
     use kurbo::Line;
+
+    #[test]
+    fn test_path_to_geo_polygon_circle() {
+        let path = Path::from(kurbo::Circle::new((0.0, 0.0), 10.0));
+
+        let polygon = path.to_geo_polygon(0.1).expect("should convert");
+        // Circle flattened should have many points
+        assert!(polygon.exterior().0.len() > 10);
+        assert!(polygon.interiors().is_empty());
+    }
+
+    #[test]
+    fn test_path_to_geo_polygon_square() {
+        let path = Path::from_svg("M 0,0 L 10,0 L 10,10 L 0,10 Z").unwrap();
+
+        let polygon = path.to_geo_polygon(0.1).expect("should convert");
+        assert_eq!(polygon.exterior().0.len(), 5); // 4 corners + closing point
+        assert!(polygon.interiors().is_empty());
+    }
+
+    #[test]
+    fn test_path_to_geo_polygon_with_hole() {
+        // Exterior square with interior square hole
+        let path =
+            Path::from_svg("M 0,0 L 10,0 L 10,10 L 0,10 Z M 3,3 L 7,3 L 7,7 L 3,7 Z").unwrap();
+
+        let polygon = path.to_geo_polygon(0.1).expect("should convert");
+        assert_eq!(polygon.interiors().len(), 1); // One hole
+    }
+
+    #[test]
+    fn test_path_to_geo_polygon_open_path_error() {
+        let path = Path::from_svg("M 0,0 L 10,0 L 10,10").unwrap();
+
+        let result = path.to_geo_polygon(0.1);
+        assert!(matches!(result, Err(ToGeoPolygonError::ExteriorNotClosed)));
+    }
+
+    #[test]
+    fn test_path_to_geo_polygon_unclosed_hole_error() {
+        // Closed exterior, unclosed interior
+        let path = Path::from_svg("M 0,0 L 10,0 L 10,10 L 0,10 Z M 3,3 L 7,3 L 7,7").unwrap();
+
+        let result = path.to_geo_polygon(0.1);
+        assert!(matches!(
+            result,
+            Err(ToGeoPolygonError::InteriorNotClosed(0))
+        ));
+    }
+
+    #[test]
+    fn test_path_to_geo_polygon_empty_path() {
+        let path = Path::default();
+        let result = path.to_geo_polygon(0.1);
+        assert!(matches!(result, Err(ToGeoPolygonError::EmptyPath)));
+    }
+
+    #[test]
+    fn test_path_buffer_shrink_square() {
+        let path = Path::from_svg("M 0,0 L 10,0 L 10,10 L 0,10 Z").unwrap();
+        let result = path.buffer(-1.0, 0.1).expect("should buffer");
+
+        assert_eq!(result.len(), 1); // Still one path
+
+        // Shrunk square should have smaller bounds
+        let bounds = result[0].bounds();
+        // 10x10 shrunk by 1 on each side ≈ 8x8
+        assert!((bounds.width() - 8.0).abs() < 0.5);
+        assert!((bounds.height() - 8.0).abs() < 0.5);
+    }
+
+    #[test]
+    fn test_path_buffer_expand_square() {
+        let path = Path::from_svg("M 0,0 L 10,0 L 10,10 L 0,10 Z").unwrap();
+        let result = path.buffer(1.0, 0.1).expect("should buffer");
+
+        assert!(!result.is_empty());
+
+        // Expanded square should have larger bounds
+        let bounds = result[0].bounds();
+        assert!(bounds.width() > 10.0);
+        assert!(bounds.height() > 10.0);
+    }
+
+    #[test]
+    fn test_path_buffer_completely_erodes() {
+        let path = Path::from_svg("M 0,0 L 2,0 L 2,2 L 0,2 Z").unwrap();
+        let result = path.buffer(-2.0, 0.1).expect("should buffer");
+
+        // Should be empty (fully eroded)
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_path_buffer_circle() {
+        let path = Path::from(kurbo::Circle::new((0.0, 0.0), 10.0));
+        let result = path.buffer(-1.0, 0.1).expect("should buffer");
+
+        assert_eq!(result.len(), 1);
+        // Shrunk circle should have smaller bounds
+        let bounds = result[0].bounds();
+        assert!(bounds.width() < 20.0); // Original diameter was 20
+    }
+
+    #[test]
+    fn test_path_buffer_open_path_error() {
+        let path = Path::from_svg("M 0,0 L 10,0").unwrap();
+        let result = path.buffer(-1.0, 0.1);
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_path_crop() {

--- a/crates/whiskers/Cargo.toml
+++ b/crates/whiskers/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 categories = ["command-line-utilities", "graphics", "visualization"]
 
 [dependencies]
-vsvg = { workspace = true, features = ["geo", "whiskers-widgets", "egui"] }
+vsvg = { workspace = true, features = ["whiskers-widgets", "egui"] }
 vsvg-viewer = { workspace = true, optional = true }
 whiskers-widgets.workspace = true
 


### PR DESCRIPTION
This PR does the following:

  - Remove `geo` feature flag from vsvg — geo is now a required dependency
  - Add `Path::to_geo_polygon(tolerance)` to convert BezPath-based paths to `geo::Polygon`
  - Add `Polyline::to_geo_polygon()` to convert polylines to `geo::Polygon`
  - Add `Path::buffer(distance, tolerance)` and `Polyline::buffer(distance)` for polygon expand/shrink operations
  - Add `ToGeoPolygonError` enum with variants: `ExteriorNotClosed`, `ExteriorTooFewPoints`, `InteriorNotClosed(usize)`, `InteriorTooFewPoints(usize)`, `EmptyPath`, `InvalidPolygon`
  - Enhance `join_paths` with a prepend phase (in addition to the existing append phase, similar to vpype), enabling path joining when a candidate's end connects to the current chain's start

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #188 
- <kbd>&nbsp;5&nbsp;</kbd> #191 
- <kbd>&nbsp;4&nbsp;</kbd> #187 
- <kbd>&nbsp;3&nbsp;</kbd> #186 
- <kbd>&nbsp;2&nbsp;</kbd> #184 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #183 
<!-- GitButler Footer Boundary Bottom -->