### PR TITLE
Add hatching algorithm to `Path` and `FlattenedPath`

### DIFF
--- a/crates/vsvg/examples/hatching.rs
+++ b/crates/vsvg/examples/hatching.rs
@@ -1,0 +1,55 @@
+//! Example demonstrating the hatching API for filling closed shapes with parallel lines.
+
+use kurbo::Shape;
+use vsvg::{Color, DocumentTrait, FlattenedPath, HatchParams, Path, PathTrait, Unit};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut doc = vsvg::Document::default();
+
+    let mut add_outline_and_hatches = |mut outline: Path, hatched: Vec<FlattenedPath>| {
+        outline.metadata_mut().color = Color::BLACK;
+        doc.push_path(0, outline);
+        for mut path in hatched {
+            path.metadata_mut().color = Color::RED;
+            doc.push_path(1, path);
+        }
+    };
+
+    // Create a circle and hatch it with horizontal lines
+    let circle = Path::from(kurbo::Circle::new((100.0, 100.0), 50.0));
+    let params = HatchParams::new(1.0 * Unit::Mm);
+    let hatched = circle.hatch(&params, 0.1)?;
+    add_outline_and_hatches(circle, hatched);
+
+    // Create a square with diagonal hatching (45 degrees)
+    let square = Path::from_svg("M 200,50 L 300,50 L 300,150 L 200,150 Z")?;
+    let params = HatchParams::new(1.0 * Unit::Mm).with_angle(std::f64::consts::FRAC_PI_4);
+    let hatched = square.hatch(&params, 0.1)?;
+    add_outline_and_hatches(square, hatched);
+
+    // Create a shape with a hole using kurbo shapes
+    let mut donut_path = kurbo::BezPath::new();
+    donut_path.extend(kurbo::Circle::new((400.0, 100.0), 60.0).path_elements(0.1));
+    donut_path.extend(kurbo::Circle::new((400.0, 100.0), 25.0).path_elements(0.1));
+    let donut = Path::from(donut_path);
+
+    let params = HatchParams::new(1.0 * Unit::Mm)
+        .with_angle(std::f64::consts::FRAC_PI_6) // 30 degrees
+        .with_inset(true); // Include boundary stroke (default)
+    let hatched = donut.hatch(&params, 0.1)?;
+
+    add_outline_and_hatches(donut, hatched);
+
+    // Demonstrate hatching without inset (lines extend to exact boundary)
+    let triangle = Path::from_svg("M 500,150 L 600,150 L 550,50 Z")?;
+    let params = HatchParams::new(1.0 * Unit::Mm)
+        .with_inset(false) // No boundary inset
+        .with_join_lines(false); // Keep lines separate (no joining)
+    let hatched = triangle.hatch(&params, 0.1)?;
+
+    add_outline_and_hatches(triangle, hatched);
+
+    doc.to_svg_file("hatching.svg")?;
+
+    Ok(())
+}

--- a/crates/vsvg/examples/hatching.rs
+++ b/crates/vsvg/examples/hatching.rs
@@ -18,13 +18,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a circle and hatch it with horizontal lines
     let circle = Path::from(kurbo::Circle::new((100.0, 100.0), 50.0));
     let params = HatchParams::new(1.0 * Unit::Mm);
-    let hatched = circle.hatch(&params, 0.1)?;
+    let hatched = circle.hatch(&params, 0.1, true)?;
     add_outline_and_hatches(circle, hatched);
 
     // Create a square with diagonal hatching (45 degrees)
     let square = Path::from_svg("M 200,50 L 300,50 L 300,150 L 200,150 Z")?;
     let params = HatchParams::new(1.0 * Unit::Mm).with_angle(std::f64::consts::FRAC_PI_4);
-    let hatched = square.hatch(&params, 0.1)?;
+    let hatched = square.hatch(&params, 0.1, true)?;
     add_outline_and_hatches(square, hatched);
 
     // Create a shape with a hole using kurbo shapes
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let params = HatchParams::new(1.0 * Unit::Mm)
         .with_angle(std::f64::consts::FRAC_PI_6) // 30 degrees
         .with_inset(true); // Include boundary stroke (default)
-    let hatched = donut.hatch(&params, 0.1)?;
+    let hatched = donut.hatch(&params, 0.1, true)?;
 
     add_outline_and_hatches(donut, hatched);
 
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let params = HatchParams::new(1.0 * Unit::Mm)
         .with_inset(false) // No boundary inset
         .with_join_lines(false); // Keep lines separate (no joining)
-    let hatched = triangle.hatch(&params, 0.1)?;
+    let hatched = triangle.hatch(&params, 0.1, true)?;
 
     add_outline_and_hatches(triangle, hatched);
 

--- a/crates/vsvg/src/hatch.rs
+++ b/crates/vsvg/src/hatch.rs
@@ -1,0 +1,392 @@
+//! Hatching algorithm for filling closed shapes with parallel lines.
+//!
+//! Plotters can only draw lines. To simulate filled shapes, we use hatching - parallel lines
+//! clipped to the shape boundary.
+//!
+//! # Example
+//! ```
+//! use vsvg::{Path, HatchParams, Unit};
+//! use kurbo::Circle;
+//!
+//! let circle = Path::from(Circle::new((50.0, 50.0), 25.0));
+//! let params = HatchParams::new(0.5 * Unit::Mm)
+//!     .with_angle(std::f64::consts::FRAC_PI_4);
+//! let paths = circle.hatch(&params, 0.1).unwrap();
+//! // paths contains inset boundary + diagonal fill lines
+//! ```
+
+use geo::Buffer;
+use geo::algorithm::bool_ops::BooleanOps;
+use geo::algorithm::bounding_rect::BoundingRect;
+use geo::algorithm::centroid::Centroid;
+use geo::algorithm::rotate::Rotate;
+
+use crate::Length;
+use crate::path::{FlattenedPath, Point, Polyline};
+
+/// Parameters for hatching a closed shape.
+#[derive(Debug, Clone, Copy)]
+pub struct HatchParams {
+    /// Spacing between hatch lines in pixels (typically `pen_width`).
+    /// Use `new()` with `impl Into<Length>` to set this with units.
+    pub spacing: f64,
+
+    /// Angle of hatch lines in radians (0 = horizontal, PI/2 = vertical).
+    pub angle: f64,
+
+    /// If true, inset the boundary by spacing/2 and include the inset boundary
+    /// as a stroke in the result. Default: true.
+    ///
+    /// When enabled, the result includes:
+    /// 1. The inset boundary path(s)
+    /// 2. The hatch lines clipped to the inset boundary
+    pub inset: bool,
+
+    /// If true, run line joining on hatch lines with tolerance = 5 * spacing.
+    /// This merges adjacent hatch lines for efficient plotting.
+    /// Default: true.
+    ///
+    /// When disabled, consider using zigzag line generation for efficiency.
+    pub join_lines: bool,
+}
+
+impl HatchParams {
+    /// Create new hatch parameters with the given spacing.
+    ///
+    /// Accepts any type that converts to [`Length`], including:
+    /// - `f64` (raw pixels)
+    /// - `1.0 * Unit::Mm` (millimeters)
+    /// - `Length::new(1.0, Unit::Cm)` (centimeters)
+    ///
+    /// Defaults: angle = 0 (horizontal), inset = true, `join_lines` = true.
+    ///
+    /// # Example
+    /// ```
+    /// use vsvg::{HatchParams, Unit};
+    ///
+    /// // Using millimeters (typical pen width)
+    /// let params = HatchParams::new(0.5 * Unit::Mm);
+    ///
+    /// // Using raw pixels
+    /// let params = HatchParams::new(2.0);
+    /// ```
+    #[must_use]
+    pub fn new(spacing: impl Into<Length>) -> Self {
+        let spacing_length: Length = spacing.into();
+        Self {
+            spacing: spacing_length.into(), // Convert Length to f64 (pixels)
+            angle: 0.0,
+            inset: true,
+            join_lines: true,
+        }
+    }
+
+    /// Set the hatch angle in radians.
+    #[must_use]
+    pub fn with_angle(mut self, angle: f64) -> Self {
+        self.angle = angle;
+        self
+    }
+
+    /// Set whether to inset the boundary. When true (default), the result includes
+    /// the inset boundary stroke plus hatch lines.
+    #[must_use]
+    pub fn with_inset(mut self, inset: bool) -> Self {
+        self.inset = inset;
+        self
+    }
+
+    /// Set whether to join adjacent hatch lines (tolerance = 5 * spacing).
+    /// When disabled, hatch lines are returned as-is.
+    #[must_use]
+    pub fn with_join_lines(mut self, join: bool) -> Self {
+        self.join_lines = join;
+        self
+    }
+}
+
+/// Convert a polygon to boundary paths (exterior + holes).
+fn polygon_to_boundary_paths(polygon: &geo::Polygon<f64>) -> Vec<FlattenedPath> {
+    let mut paths = Vec::new();
+
+    // Exterior ring
+    let exterior_points: Vec<Point> = polygon
+        .exterior()
+        .0
+        .iter()
+        .map(|c| Point::new(c.x, c.y))
+        .collect();
+    if exterior_points.len() >= 3 {
+        paths.push(FlattenedPath::from(Polyline::new(exterior_points)));
+    }
+
+    // Interior rings (holes)
+    for interior in polygon.interiors() {
+        let hole_points: Vec<Point> = interior.0.iter().map(|c| Point::new(c.x, c.y)).collect();
+        if hole_points.len() >= 3 {
+            paths.push(FlattenedPath::from(Polyline::new(hole_points)));
+        }
+    }
+
+    paths
+}
+
+/// Generate hatching for a `geo::Polygon`.
+///
+/// This is the core algorithm. Use [`crate::Path::hatch`] or [`Polyline::hatch`] for
+/// convenience methods that handle conversion.
+///
+/// # Arguments
+/// * `polygon` - A valid, closed polygon (may have holes)
+/// * `params` - Hatching parameters
+///
+/// # Returns
+/// A `Vec<FlattenedPath>` containing boundary paths (if inset enabled) and hatch lines.
+/// Returns empty vec if shape is fully eroded.
+#[must_use]
+pub fn hatch_polygon(polygon: &geo::Polygon<f64>, params: &HatchParams) -> Vec<FlattenedPath> {
+    // Early return for invalid spacing
+    if params.spacing <= 0.0 {
+        return vec![];
+    }
+
+    let mut result: Vec<FlattenedPath> = Vec::new();
+
+    // Step 3: Inset and boundary extraction
+    let work_polygon = if params.inset {
+        let inset_distance = -params.spacing / 2.0;
+        let multi = polygon.buffer(inset_distance);
+
+        // Buffer can return multiple polygons (if shape splits) or empty (eroded)
+        if multi.0.is_empty() {
+            return vec![]; // Fully eroded
+        }
+
+        // Convert all inset polygons to boundary paths, add to result
+        for poly in &multi.0 {
+            result.extend(polygon_to_boundary_paths(poly));
+        }
+
+        // Use the largest polygon for hatching
+        // Safety: we checked is_empty() above, so max_by always returns Some
+        let Some(largest) = multi.0.into_iter().max_by(|a, b| {
+            use geo::algorithm::area::Area;
+            a.unsigned_area()
+                .partial_cmp(&b.unsigned_area())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        }) else {
+            return result; // Should never happen, but handle gracefully
+        };
+        largest
+    } else {
+        polygon.clone()
+    };
+
+    // Get centroid for rotation
+    let centroid = work_polygon.centroid().unwrap_or(geo::Point::new(0.0, 0.0));
+
+    // Step 5: Rotate polygon so hatch lines become horizontal
+    let rotated_poly = work_polygon.rotate_around_point(-params.angle.to_degrees(), centroid);
+
+    // Get bounds of rotated polygon
+    let Some(bounds) = rotated_poly.bounding_rect() else {
+        return result; // Degenerate polygon
+    };
+    let (x_min, x_max) = (bounds.min().x - 1.0, bounds.max().x + 1.0);
+    let (y_min, y_max) = (bounds.min().y, bounds.max().y);
+
+    // Step 6: Generate horizontal scan lines as MultiLineString
+    let mut lines: Vec<geo::LineString<f64>> = Vec::new();
+    let mut y = y_min + params.spacing / 2.0; // Start half-spacing from edge
+
+    while y < y_max {
+        let line =
+            geo::LineString::new(vec![geo::Coord { x: x_min, y }, geo::Coord { x: x_max, y }]);
+        lines.push(line);
+        y += params.spacing;
+    }
+
+    if lines.is_empty() {
+        return result; // Shape too small for any hatch lines
+    }
+
+    let scan_lines = geo::MultiLineString::new(lines);
+
+    // Step 7: Clip scan lines against the rotated polygon
+    // invert=false means keep the parts INSIDE the polygon
+    let clipped: geo::MultiLineString<f64> = rotated_poly.clip(&scan_lines, false);
+
+    // Step 8: Rotate clipped lines back to original orientation
+    let result_lines: geo::MultiLineString<f64> =
+        clipped.rotate_around_point(params.angle.to_degrees(), centroid);
+
+    // Step 9: Convert clipped lines to FlattenedPath, add to result
+    let hatch_lines: Vec<FlattenedPath> = result_lines
+        .0
+        .into_iter()
+        .filter(|ls| ls.0.len() >= 2)
+        .map(|ls| {
+            let points: Vec<Point> = ls.0.iter().map(|c| Point::new(c.x, c.y)).collect();
+            FlattenedPath::from(Polyline::new(points))
+        })
+        .collect();
+
+    result.extend(hatch_lines);
+
+    // Step 10: Optional line joining for efficiency
+    if params.join_lines && result.len() > 1 {
+        let join_tolerance = params.spacing * 5.0;
+        crate::optimization::join_paths(&mut result, join_tolerance, true);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_square_polygon(size: f64) -> geo::Polygon<f64> {
+        geo::Polygon::new(
+            geo::LineString::new(vec![
+                geo::Coord { x: 0.0, y: 0.0 },
+                geo::Coord { x: size, y: 0.0 },
+                geo::Coord { x: size, y: size },
+                geo::Coord { x: 0.0, y: size },
+                geo::Coord { x: 0.0, y: 0.0 },
+            ]),
+            vec![],
+        )
+    }
+
+    fn make_circle_linestring(cx: f64, cy: f64, r: f64, n: usize) -> geo::LineString<f64> {
+        let coords: Vec<_> = (0..=n)
+            .map(|i| {
+                let theta = 2.0 * std::f64::consts::PI * (i % n) as f64 / n as f64;
+                geo::Coord {
+                    x: cx + r * theta.cos(),
+                    y: cy + r * theta.sin(),
+                }
+            })
+            .collect();
+        geo::LineString::new(coords)
+    }
+
+    #[test]
+    fn hatch_simple_square() {
+        let polygon = make_square_polygon(10.0);
+        let params = HatchParams::new(2.0)
+            .with_inset(false)
+            .with_join_lines(false);
+        let paths = hatch_polygon(&polygon, &params);
+
+        // ~5 horizontal lines expected (no boundary since inset=false, no joining)
+        assert!(!paths.is_empty());
+        assert!(paths.len() >= 3);
+    }
+
+    #[test]
+    fn hatch_with_inset_includes_boundary() {
+        let polygon = make_square_polygon(10.0);
+        let params = HatchParams::new(2.0); // inset=true by default
+
+        let paths = hatch_polygon(&polygon, &params);
+
+        // Should have boundary + hatch lines
+        assert!(!paths.is_empty());
+
+        // More paths than without inset (boundary adds paths)
+        let params_no_inset = HatchParams::new(2.0).with_inset(false);
+        let paths_no_inset = hatch_polygon(&polygon, &params_no_inset);
+        assert!(paths.len() >= paths_no_inset.len());
+    }
+
+    #[test]
+    fn hatch_square_with_angle() {
+        let polygon = make_square_polygon(10.0);
+        let params = HatchParams::new(1.0)
+            .with_angle(std::f64::consts::FRAC_PI_4)
+            .with_inset(false);
+
+        let paths = hatch_polygon(&polygon, &params);
+        assert!(!paths.is_empty());
+    }
+
+    #[test]
+    fn hatch_with_hole() {
+        // Square with square hole
+        let exterior = geo::LineString::new(vec![
+            geo::Coord { x: 0.0, y: 0.0 },
+            geo::Coord { x: 10.0, y: 0.0 },
+            geo::Coord { x: 10.0, y: 10.0 },
+            geo::Coord { x: 0.0, y: 10.0 },
+            geo::Coord { x: 0.0, y: 0.0 },
+        ]);
+        let hole = geo::LineString::new(vec![
+            geo::Coord { x: 3.0, y: 3.0 },
+            geo::Coord { x: 7.0, y: 3.0 },
+            geo::Coord { x: 7.0, y: 7.0 },
+            geo::Coord { x: 3.0, y: 7.0 },
+            geo::Coord { x: 3.0, y: 3.0 },
+        ]);
+        let polygon = geo::Polygon::new(exterior, vec![hole]);
+
+        let params = HatchParams::new(1.0).with_inset(false);
+        let paths = hatch_polygon(&polygon, &params);
+
+        // Lines through center should be split by hole
+        assert!(!paths.is_empty());
+    }
+
+    #[test]
+    fn hatch_fully_eroded() {
+        let polygon = make_square_polygon(2.0); // Small square
+        let params = HatchParams::new(4.0); // Large spacing, insets by 2.0
+
+        let paths = hatch_polygon(&polygon, &params);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn hatch_with_line_joining() {
+        let polygon = make_square_polygon(10.0);
+        let params = HatchParams::new(1.0)
+            .with_inset(false)
+            .with_join_lines(true);
+
+        let paths = hatch_polygon(&polygon, &params);
+
+        // With joining, should have fewer paths than without
+        let params_no_join = HatchParams::new(1.0)
+            .with_inset(false)
+            .with_join_lines(false);
+        let paths_no_join = hatch_polygon(&polygon, &params_no_join);
+
+        assert!(paths.len() <= paths_no_join.len());
+    }
+
+    #[test]
+    fn hatch_circle() {
+        let circle = geo::Polygon::new(make_circle_linestring(50.0, 50.0, 25.0, 64), vec![]);
+        let params = HatchParams::new(2.0);
+        let paths = hatch_polygon(&circle, &params);
+
+        assert!(!paths.is_empty());
+    }
+
+    #[test]
+    fn hatch_zero_spacing_returns_empty() {
+        let polygon = make_square_polygon(10.0);
+        let params = HatchParams::new(0.0);
+        let paths = hatch_polygon(&polygon, &params);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn hatch_negative_spacing_returns_empty() {
+        let polygon = make_square_polygon(10.0);
+        let params = HatchParams::new(-1.0);
+        let paths = hatch_polygon(&polygon, &params);
+        assert!(paths.is_empty());
+    }
+}

--- a/crates/vsvg/src/hatch.rs
+++ b/crates/vsvg/src/hatch.rs
@@ -11,7 +11,7 @@
 //! let circle = Path::from(Circle::new((50.0, 50.0), 25.0));
 //! let params = HatchParams::new(0.5 * Unit::Mm)
 //!     .with_angle(std::f64::consts::FRAC_PI_4);
-//! let paths = circle.hatch(&params, 0.1).unwrap();
+//! let paths = circle.hatch(&params, 0.1, true).unwrap();
 //! // paths contains inset boundary + diagonal fill lines
 //! ```
 

--- a/crates/vsvg/src/hatch.rs
+++ b/crates/vsvg/src/hatch.rs
@@ -118,7 +118,6 @@ impl HatchParams {
 /// A `Vec<FlattenedPath>` containing boundary paths (if inset enabled) and hatch lines.
 /// Returns empty vec if shape is fully eroded.
 #[must_use]
-#[expect(clippy::too_many_lines)]
 pub fn hatch_polygon(polygon: &geo::Polygon<f64>, params: &HatchParams) -> Vec<FlattenedPath> {
     // Early return for invalid spacing
     if params.spacing <= 0.0 {
@@ -133,8 +132,10 @@ pub fn hatch_polygon(polygon: &geo::Polygon<f64>, params: &HatchParams) -> Vec<F
     let boundary_inset = -params.spacing / 2.0;
     let clip_inset = -params.spacing;
 
-    // Step 3: Compute clipping polygon for scan lines
-    let work_polygon = if params.inset {
+    // Step 3: Compute clipping region for scan lines.
+    // The buffer/inset may split the polygon into multiple disconnected pieces (islands),
+    // so we keep the full MultiPolygon to ensure all islands get hatch lines.
+    let work_multi = if params.inset {
         // First inset: the boundary stroke position
         let boundary_multi = polygon.buffer(boundary_inset);
         if boundary_multi.0.is_empty() {
@@ -152,16 +153,7 @@ pub fn hatch_polygon(polygon: &geo::Polygon<f64>, params: &HatchParams) -> Vec<F
             return result; // Shape too small for hatch lines, but boundary exists
         }
 
-        // Use largest polygon for clipping
-        let Some(largest) = clip_multi.0.into_iter().max_by(|a, b| {
-            use geo::algorithm::area::Area;
-            a.unsigned_area()
-                .partial_cmp(&b.unsigned_area())
-                .unwrap_or(std::cmp::Ordering::Equal)
-        }) else {
-            return result; // Should never happen, but handle gracefully
-        };
-        largest
+        clip_multi
     } else {
         // No boundary: clip scan lines at spacing/2 from original (line edges touch boundary)
         let no_boundary_clip = -params.spacing / 2.0;
@@ -170,22 +162,14 @@ pub fn hatch_polygon(polygon: &geo::Polygon<f64>, params: &HatchParams) -> Vec<F
             return vec![]; // Fully eroded
         }
 
-        let Some(largest) = multi.0.into_iter().max_by(|a, b| {
-            use geo::algorithm::area::Area;
-            a.unsigned_area()
-                .partial_cmp(&b.unsigned_area())
-                .unwrap_or(std::cmp::Ordering::Equal)
-        }) else {
-            return vec![]; // Should never happen, but handle gracefully
-        };
-        largest
+        multi
     };
 
     // Get centroid for rotation
-    let centroid = work_polygon.centroid().unwrap_or(geo::Point::new(0.0, 0.0));
+    let centroid = work_multi.centroid().unwrap_or(geo::Point::new(0.0, 0.0));
 
     // Step 5: Rotate polygon so hatch lines become horizontal
-    let rotated_poly = work_polygon.rotate_around_point(-params.angle.to_degrees(), centroid);
+    let rotated_poly = work_multi.rotate_around_point(-params.angle.to_degrees(), centroid);
 
     // Get bounds of rotated polygon
     let Some(bounds) = rotated_poly.bounding_rect() else {
@@ -403,6 +387,343 @@ mod tests {
         let paths = hatch_polygon(&circle, &params);
 
         assert!(!paths.is_empty());
+    }
+
+    /// Helper: build the crescent polygon from the regression case.
+    fn make_crescent_polygon() -> geo::Polygon<f64> {
+        geo::Polygon::new(
+            geo::LineString::new(vec![
+                geo::Coord {
+                    x: 247.87514301547856,
+                    y: 156.80109891178108,
+                },
+                geo::Coord {
+                    x: 246.1818618417725,
+                    y: 156.19523319484688,
+                },
+                geo::Coord {
+                    x: 246.5739459634766,
+                    y: 156.05494317295052,
+                },
+                geo::Coord {
+                    x: 248.72240587482304,
+                    y: 155.5167821335981,
+                },
+                geo::Coord {
+                    x: 250.91326924571842,
+                    y: 155.19179829837776,
+                },
+                geo::Coord {
+                    x: 253.1254369855866,
+                    y: 155.08312138797737,
+                },
+                geo::Coord {
+                    x: 255.33760472545475,
+                    y: 155.19179829837776,
+                },
+                geo::Coord {
+                    x: 257.52846809635014,
+                    y: 155.5167821335981,
+                },
+                geo::Coord {
+                    x: 259.676927769278,
+                    y: 156.05494317295052,
+                },
+                geo::Coord {
+                    x: 261.76229330310673,
+                    y: 156.80109891178108,
+                },
+                geo::Coord {
+                    x: 263.76448079357,
+                    y: 157.7480631756971,
+                },
+                geo::Coord {
+                    x: 265.05235620746464,
+                    y: 158.5199857640455,
+                },
+                geo::Coord {
+                    x: 264.7895817399964,
+                    y: 158.95839866878487,
+                },
+                geo::Coord {
+                    x: 263.78258320102543,
+                    y: 161.087517826576,
+                },
+                geo::Coord {
+                    x: 262.9891240240082,
+                    y: 163.3050881314466,
+                },
+                geo::Coord {
+                    x: 262.41684528598637,
+                    y: 165.58975252391792,
+                },
+                geo::Coord {
+                    x: 262.07125874767155,
+                    y: 167.91950902225472,
+                },
+                geo::Coord {
+                    x: 261.9556920171723,
+                    y: 170.27192029239632,
+                },
+                geo::Coord {
+                    x: 262.07125874767155,
+                    y: 172.6243318009565,
+                },
+                geo::Coord {
+                    x: 262.41684528598637,
+                    y: 174.9540880608747,
+                },
+                geo::Coord {
+                    x: 262.9891240240082,
+                    y: 177.23875245334602,
+                },
+                geo::Coord {
+                    x: 263.78258320102543,
+                    y: 179.45632275821663,
+                },
+                geo::Coord {
+                    x: 264.7895817399964,
+                    y: 181.58544191600777,
+                },
+                geo::Coord {
+                    x: 266.00042148837895,
+                    y: 183.6056059289167,
+                },
+                geo::Coord {
+                    x: 267.4034411550507,
+                    y: 185.497359125633,
+                },
+                geo::Coord {
+                    x: 268.9851293207154,
+                    y: 187.24248298885323,
+                },
+                geo::Coord {
+                    x: 270.7302531839356,
+                    y: 188.8241711545179,
+                },
+                geo::Coord {
+                    x: 272.1009976507172,
+                    y: 189.84078439952827,
+                },
+                geo::Coord {
+                    x: 271.89103504428715,
+                    y: 190.19108614208199,
+                },
+                geo::Coord {
+                    x: 270.57165905246586,
+                    y: 191.9700587678144,
+                },
+                geo::Coord {
+                    x: 269.0842663885102,
+                    y: 193.61114391567207,
+                },
+                geo::Coord {
+                    x: 267.4431814790711,
+                    y: 195.09853657962776,
+                },
+                geo::Coord {
+                    x: 265.66420885333866,
+                    y: 196.41791257144905,
+                },
+                geo::Coord {
+                    x: 263.76448079357,
+                    y: 197.5565656113813,
+                },
+                geo::Coord {
+                    x: 261.76229330310673,
+                    y: 198.50352987529732,
+                },
+                geo::Coord {
+                    x: 259.676927769278,
+                    y: 199.24968561412788,
+                },
+                geo::Coord {
+                    x: 257.52846809635014,
+                    y: 199.7878466534803,
+                },
+                geo::Coord {
+                    x: 255.33760472545475,
+                    y: 200.11283048870064,
+                },
+                geo::Coord {
+                    x: 253.1254369855866,
+                    y: 200.22150739910103,
+                },
+                geo::Coord {
+                    x: 250.91326924571842,
+                    y: 200.11283048870064,
+                },
+                geo::Coord {
+                    x: 248.72240587482304,
+                    y: 199.7878466534803,
+                },
+                geo::Coord {
+                    x: 246.5739459634766,
+                    y: 199.24968561412788,
+                },
+                geo::Coord {
+                    x: 246.1818618417725,
+                    y: 199.10939559223152,
+                },
+                geo::Coord {
+                    x: 247.87514301547856,
+                    y: 198.50352987529732,
+                },
+                geo::Coord {
+                    x: 249.8773307443604,
+                    y: 197.5565656113813,
+                },
+                geo::Coord {
+                    x: 251.7770585657105,
+                    y: 196.41791257144905,
+                },
+                geo::Coord {
+                    x: 253.5560314298615,
+                    y: 195.09853657962776,
+                },
+                geo::Coord {
+                    x: 255.19711633930058,
+                    y: 193.61114391567207,
+                },
+                geo::Coord {
+                    x: 256.68450900325627,
+                    y: 191.9700587678144,
+                },
+                geo::Coord {
+                    x: 258.00388499507756,
+                    y: 190.19108614208199,
+                },
+                geo::Coord {
+                    x: 259.1425380350098,
+                    y: 188.2913583207319,
+                },
+                geo::Coord {
+                    x: 260.0895022989258,
+                    y: 186.28917059185005,
+                },
+                geo::Coord {
+                    x: 260.8356580377564,
+                    y: 184.2038052964399,
+                },
+                geo::Coord {
+                    x: 261.3738190771088,
+                    y: 182.05534562351204,
+                },
+                geo::Coord {
+                    x: 261.69880291232914,
+                    y: 179.86448225261665,
+                },
+                geo::Coord {
+                    x: 261.80747982272953,
+                    y: 177.6523142743299,
+                },
+                geo::Coord {
+                    x: 261.69880291232914,
+                    y: 175.44014653446175,
+                },
+                geo::Coord {
+                    x: 261.3738190771088,
+                    y: 173.24928316356636,
+                },
+                geo::Coord {
+                    x: 260.8356580377564,
+                    y: 171.1008234906385,
+                },
+                geo::Coord {
+                    x: 260.0895022989258,
+                    y: 169.01545819522835,
+                },
+                geo::Coord {
+                    x: 259.1425380350098,
+                    y: 167.0132704663465,
+                },
+                geo::Coord {
+                    x: 258.00388499507756,
+                    y: 165.11354264499641,
+                },
+                geo::Coord {
+                    x: 256.68450900325627,
+                    y: 163.334570019264,
+                },
+                geo::Coord {
+                    x: 255.19711633930058,
+                    y: 161.69348487140633,
+                },
+                geo::Coord {
+                    x: 253.5560314298615,
+                    y: 160.20609220745064,
+                },
+                geo::Coord {
+                    x: 251.7770585657105,
+                    y: 158.88671621562935,
+                },
+                geo::Coord {
+                    x: 249.8773307443604,
+                    y: 157.7480631756971,
+                },
+                geo::Coord {
+                    x: 247.87514301547856,
+                    y: 156.80109891178108,
+                },
+            ]),
+            vec![],
+        )
+    }
+
+    /// Regression test: thin crescent polygon that splits into two islands when inset.
+    ///
+    /// This polygon is a valid, non-self-intersecting crescent (C-shape) produced by
+    /// `geo::MultiPolygon::difference`. Its connecting band is thin enough that
+    /// `buffer(-spacing)` splits it into two separate polygons (upper and lower islands).
+    /// Both islands must receive hatch lines.
+    #[test]
+    fn hatch_crescent_covers_both_islands() {
+        let polygon = make_crescent_polygon();
+
+        // Verify preconditions
+        use geo::algorithm::validation::Validation;
+        assert!(polygon.is_valid(), "test polygon must be valid");
+
+        // At spacing=0.567 (0.15mm pen), clip_inset=-0.567 splits into 2 islands:
+        //   Upper: Y≈[155.7, 171.1], area≈84
+        //   Lower: Y≈[177.0, 199.7], area≈171
+        let spacing = 0.567;
+        let params = HatchParams::new(spacing)
+            .with_join_lines(false)
+            .with_inset(true);
+        let paths = hatch_polygon(&polygon, &params);
+
+        // Separate boundary paths (closed) from hatch lines (open)
+        let hatch_lines: Vec<&FlattenedPath> = paths
+            .iter()
+            .filter(|p| {
+                let pts = p.data.points();
+                pts.len() >= 2 && pts.first() != pts.last()
+            })
+            .collect();
+
+        assert!(!hatch_lines.is_empty(), "should have hatch lines");
+
+        // The two islands are separated around Y≈172-176.
+        // Hatch lines must exist in BOTH the upper and lower islands.
+        let upper_threshold = 170.0;
+        let lower_threshold = 178.0;
+
+        let has_upper_hatch = hatch_lines
+            .iter()
+            .any(|p| p.data.points().iter().any(|pt| pt.y() < upper_threshold));
+        let has_lower_hatch = hatch_lines
+            .iter()
+            .any(|p| p.data.points().iter().any(|pt| pt.y() > lower_threshold));
+
+        assert!(
+            has_upper_hatch,
+            "upper island (Y < {upper_threshold}) must have hatch lines"
+        );
+        assert!(
+            has_lower_hatch,
+            "lower island (Y > {lower_threshold}) must have hatch lines"
+        );
     }
 
     #[test]

--- a/crates/vsvg/src/lib.rs
+++ b/crates/vsvg/src/lib.rs
@@ -11,6 +11,7 @@ mod catmull_rom;
 mod color;
 mod crop;
 mod document;
+mod hatch;
 mod layer;
 mod length;
 mod optimization;
@@ -32,6 +33,7 @@ pub use catmull_rom::*;
 pub use color::*;
 pub use crop::*;
 pub use document::*;
+pub use hatch::{HatchParams, hatch_polygon};
 pub use layer::*;
 pub use length::*;
 #[allow(unused_imports)]

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -145,12 +145,18 @@ impl Polyline {
 }
 
 /// Convert `geo::MultiPolygon` to `Vec<FlattenedPath>`.
-fn multi_polygon_to_flattened_paths(mp: &geo::MultiPolygon<f64>) -> Vec<FlattenedPath> {
+///
+/// Returns one path for each polygon's exterior and interior rings.
+#[must_use]
+pub fn multi_polygon_to_flattened_paths(mp: &geo::MultiPolygon<f64>) -> Vec<FlattenedPath> {
     mp.0.iter().flat_map(polygon_to_flattened_paths).collect()
 }
 
 /// Convert `geo::Polygon` to `Vec<FlattenedPath>`.
-fn polygon_to_flattened_paths(polygon: &geo::Polygon<f64>) -> Vec<FlattenedPath> {
+///
+/// Returns one path for the exterior and one for each interior (hole).
+#[must_use]
+pub fn polygon_to_flattened_paths(polygon: &geo::Polygon<f64>) -> Vec<FlattenedPath> {
     let mut result = Vec::new();
 
     // Exterior ring

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -386,6 +386,24 @@ impl kurbo::ParamCurveFit for PolylineCurveFit<'_> {
 }
 
 impl FlattenedPath {
+    /// Generate hatching (parallel fill lines) for this closed path.
+    ///
+    /// See [`crate::HatchParams`] for configuration options.
+    ///
+    /// # Errors
+    /// Returns error if the path is not closed or cannot form a valid polygon.
+    pub fn hatch(
+        &self,
+        params: &crate::HatchParams,
+    ) -> Result<Vec<FlattenedPath>, super::ToGeoPolygonError> {
+        let mut result = self.data.hatch(params)?;
+
+        for path in &mut result {
+            *path.metadata_mut() = self.metadata.clone();
+        }
+        Ok(result)
+    }
+
     /// Fit smooth Bézier curves to this polyline.
     ///
     /// This is the inverse of [`Path::flatten`]: it converts a sequence of points back into

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -401,11 +401,14 @@ impl FlattenedPath {
     pub fn hatch(
         &self,
         params: &crate::HatchParams,
+        inherit_metadata: bool,
     ) -> Result<Vec<FlattenedPath>, super::ToGeoPolygonError> {
         let mut result = self.data.hatch(params)?;
 
-        for path in &mut result {
-            *path.metadata_mut() = self.metadata.clone();
+        if inherit_metadata {
+            for path in &mut result {
+                *path.metadata_mut() = self.metadata.clone();
+            }
         }
         Ok(result)
     }

--- a/crates/vsvg/src/path/flattened_path.rs
+++ b/crates/vsvg/src/path/flattened_path.rs
@@ -128,6 +128,20 @@ impl Polyline {
 
         Ok(multi_polygon_to_flattened_paths(&multi_polygon))
     }
+
+    /// Generate hatching for this closed polyline.
+    ///
+    /// Same as [`crate::Path::hatch`] but for already-flattened paths (no tolerance needed).
+    ///
+    /// # Errors
+    /// Returns error if the polyline is not closed or cannot form a valid polygon.
+    pub fn hatch(
+        &self,
+        params: &crate::HatchParams,
+    ) -> Result<Vec<FlattenedPath>, super::ToGeoPolygonError> {
+        let polygon = self.to_geo_polygon()?;
+        Ok(crate::hatch_polygon(&polygon, params))
+    }
 }
 
 /// Convert `geo::MultiPolygon` to `Vec<FlattenedPath>`.

--- a/crates/vsvg/src/path/mod.rs
+++ b/crates/vsvg/src/path/mod.rs
@@ -7,7 +7,9 @@ mod point;
 
 use crate::{SvgPathWriter, Transforms};
 
-pub use flattened_path::{FlattenedPath, Polyline};
+pub use flattened_path::{
+    FlattenedPath, Polyline, multi_polygon_to_flattened_paths, polygon_to_flattened_paths,
+};
 pub use into_bezpath::{IntoBezPath, IntoBezPathTolerance};
 pub use metadata::PathMetadata;
 pub use path::Path;

--- a/crates/vsvg/src/path/path.rs
+++ b/crates/vsvg/src/path/path.rs
@@ -1,4 +1,7 @@
-use super::{FlattenedPath, PathDataTrait, PathMetadata, PathTrait, Point, Polyline};
+use super::{
+    FlattenedPath, PathDataTrait, PathMetadata, PathTrait, Point, Polyline,
+    multi_polygon_to_flattened_paths,
+};
 use crate::Transforms;
 use crate::crop::{Crop, QuadCropResult, crop_quad_bezier};
 use crate::path::into_bezpath::{
@@ -485,39 +488,6 @@ impl Path {
 
         Ok(result)
     }
-}
-
-/// Convert `geo::MultiPolygon` to `Vec<FlattenedPath>`.
-fn multi_polygon_to_flattened_paths(mp: &geo::MultiPolygon<f64>) -> Vec<FlattenedPath> {
-    mp.0.iter().flat_map(polygon_to_flattened_paths).collect()
-}
-
-/// Convert `geo::Polygon` to `Vec<FlattenedPath>`.
-///
-/// Returns one path for the exterior and one for each interior (hole).
-fn polygon_to_flattened_paths(polygon: &geo::Polygon<f64>) -> Vec<FlattenedPath> {
-    let mut result = Vec::new();
-
-    // Exterior ring
-    let exterior_points: Vec<Point> = polygon
-        .exterior()
-        .0
-        .iter()
-        .map(|c| Point::new(c.x, c.y))
-        .collect();
-    if exterior_points.len() >= 3 {
-        result.push(FlattenedPath::from(Polyline::new(exterior_points)));
-    }
-
-    // Interior rings (holes) as separate paths
-    for interior in polygon.interiors() {
-        let hole_points: Vec<Point> = interior.0.iter().map(|c| Point::new(c.x, c.y)).collect();
-        if hole_points.len() >= 3 {
-            result.push(FlattenedPath::from(Polyline::new(hole_points)));
-        }
-    }
-
-    result
 }
 
 impl<T: IntoBezPath> From<T> for Path {

--- a/crates/vsvg/src/path/path.rs
+++ b/crates/vsvg/src/path/path.rs
@@ -442,6 +442,49 @@ impl Path {
 
         Ok(multi_polygon_to_flattened_paths(&multi_polygon))
     }
+
+    /// Generate hatching (boundary + fill lines) for this closed path.
+    ///
+    /// Returns a `Vec<FlattenedPath>` containing:
+    /// - The inset boundary path(s) if `params.inset` is true
+    /// - The parallel fill lines clipped to the boundary
+    ///
+    /// Returns an empty vec if the shape is too small or fully eroded by inset.
+    ///
+    /// # Arguments
+    /// * `params` - Hatching parameters (spacing, angle, inset, `join_lines`)
+    /// * `tolerance` - Curve flattening tolerance
+    ///
+    /// # Errors
+    /// Returns error if the path cannot be converted to a polygon
+    /// (not closed, self-intersecting, etc.).
+    ///
+    /// # Example
+    /// ```
+    /// use vsvg::{Path, HatchParams, Unit};
+    /// use kurbo::Circle;
+    ///
+    /// let circle = Path::from(Circle::new((50.0, 50.0), 25.0));
+    /// let params = HatchParams::new(0.5 * Unit::Mm)
+    ///     .with_angle(std::f64::consts::FRAC_PI_4);
+    /// let paths = circle.hatch(&params, 0.1).unwrap();
+    /// // paths contains inset boundary + diagonal fill lines
+    /// ```
+    pub fn hatch(
+        &self,
+        params: &crate::HatchParams,
+        tolerance: f64,
+    ) -> Result<Vec<FlattenedPath>, super::ToGeoPolygonError> {
+        let polygon = self.to_geo_polygon(tolerance)?;
+        let mut result = crate::hatch_polygon(&polygon, params);
+
+        // Copy metadata to all generated paths
+        for path in &mut result {
+            *path.metadata_mut() = self.metadata.clone();
+        }
+
+        Ok(result)
+    }
 }
 
 /// Convert `geo::MultiPolygon` to `Vec<FlattenedPath>`.

--- a/crates/vsvg/src/path/path.rs
+++ b/crates/vsvg/src/path/path.rs
@@ -470,20 +470,22 @@ impl Path {
     /// let circle = Path::from(Circle::new((50.0, 50.0), 25.0));
     /// let params = HatchParams::new(0.5 * Unit::Mm)
     ///     .with_angle(std::f64::consts::FRAC_PI_4);
-    /// let paths = circle.hatch(&params, 0.1).unwrap();
+    /// let paths = circle.hatch(&params, 0.1, true).unwrap();
     /// // paths contains inset boundary + diagonal fill lines
     /// ```
     pub fn hatch(
         &self,
         params: &crate::HatchParams,
         tolerance: f64,
+        inherit_metadata: bool,
     ) -> Result<Vec<FlattenedPath>, super::ToGeoPolygonError> {
         let polygon = self.to_geo_polygon(tolerance)?;
         let mut result = crate::hatch_polygon(&polygon, params);
 
-        // Copy metadata to all generated paths
-        for path in &mut result {
-            *path.metadata_mut() = self.metadata.clone();
+        if inherit_metadata {
+            for path in &mut result {
+                *path.metadata_mut() = self.metadata.clone();
+            }
         }
 
         Ok(result)


### PR DESCRIPTION
Add low-level support for hatching closed polygon. This supports polygons with holes via compound `Path`. In such case, the first sub-path is considered to be the exterior boundary, and the subsequent sub-paths holes. 

Change summary:
- added low-level `hatch_polygon` and `HatchParams`
- added `Polyline::hatch()`, `FlattenedPath::hatch()` and `Path::hatch()`

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #188 
- <kbd>&nbsp;5&nbsp;</kbd> #191 
- <kbd>&nbsp;4&nbsp;</kbd> #187 
- <kbd>&nbsp;3&nbsp;</kbd> #186 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #184 
- <kbd>&nbsp;1&nbsp;</kbd> #183 
<!-- GitButler Footer Boundary Bottom -->

