### PR TITLE
Introduce `IntoBezPaths` trait

### DIFF
--- a/crates/vsvg/src/path/into_bezpath.rs
+++ b/crates/vsvg/src/path/into_bezpath.rs
@@ -23,6 +23,33 @@ impl<T: IntoBezPathTolerance> IntoBezPath for T {
     }
 }
 
+/// Converts into one or more `BezPath`s, preserving structural boundaries.
+///
+/// Single-geometry types get this via blanket impl from [`IntoBezPathTolerance`].
+/// Multi-geometry types (e.g. `geo::MultiPolygon`) override to return one `BezPath`
+/// per constituent, which is critical for correct hatching.
+pub trait IntoBezPathsTolerance {
+    fn into_bezpaths_with_tolerance(self, tolerance: f64) -> Vec<BezPath>;
+}
+
+/// Convenience trait; blanket-implemented via [`IntoBezPathsTolerance`] with default tolerance.
+pub trait IntoBezPaths {
+    fn into_bezpaths(self) -> Vec<BezPath>;
+}
+
+impl<T: IntoBezPathsTolerance> IntoBezPaths for T {
+    fn into_bezpaths(self) -> Vec<BezPath> {
+        <Self as IntoBezPathsTolerance>::into_bezpaths_with_tolerance(self, DEFAULT_TOLERANCE)
+    }
+}
+
+/// Blanket: any single-BezPath type automatically yields a one-element Vec.
+impl<T: IntoBezPathTolerance> IntoBezPathsTolerance for T {
+    fn into_bezpaths_with_tolerance(self, tolerance: f64) -> Vec<BezPath> {
+        vec![self.into_bezpath_with_tolerance(tolerance)]
+    }
+}
+
 impl IntoBezPathTolerance for &[(f64, f64)] {
     fn into_bezpath_with_tolerance(self, _tolerance: f64) -> BezPath {
         points_to_bezpath(self.iter().copied())
@@ -197,6 +224,31 @@ pub mod geo_impl {
         }
     }
 
+    // Macro to implement `IntoBezPathTolerance` for non-reference types (e.g., `geo::Polygon`),
+    // by taking a reference and delegating to the implementations given above.
+    macro_rules! geo_object_into_bezpath {
+        ( $ t: ty) => {
+            impl IntoBezPathTolerance for $t {
+                #[inline]
+                fn into_bezpath_with_tolerance(self, tolerance: f64) -> BezPath {
+                    (&self).into_bezpath_with_tolerance(tolerance)
+                }
+            }
+        };
+    }
+
+    geo_object_into_bezpath!(geo::Point<f64>);
+    geo_object_into_bezpath!(geo::Line<f64>);
+    geo_object_into_bezpath!(geo::LineString<f64>);
+    geo_object_into_bezpath!(geo::Polygon<f64>);
+    geo_object_into_bezpath!(geo::MultiPoint<f64>);
+    geo_object_into_bezpath!(geo::MultiLineString<f64>);
+    geo_object_into_bezpath!(geo::MultiPolygon<f64>);
+    geo_object_into_bezpath!(geo::Rect<f64>);
+    geo_object_into_bezpath!(geo::Triangle<f64>);
+    geo_object_into_bezpath!(geo::Geometry<f64>);
+    geo_object_into_bezpath!(geo::GeometryCollection<f64>);
+
     impl IntoBezPathTolerance for &geo::Geometry<f64> {
         fn into_bezpath_with_tolerance(self, tolerance: f64) -> BezPath {
             match self {
@@ -225,31 +277,6 @@ pub mod geo_impl {
             }
         }
     }
-
-    // Macro to implement `IntoBezPathTolerance` for non-reference types (e.g., `geo::Polygon`),
-    // by taking a reference and delegating to the implementations given above.
-    macro_rules! geo_object_into_bezpath {
-        ( $ t: ty) => {
-            impl IntoBezPathTolerance for $t {
-                #[inline]
-                fn into_bezpath_with_tolerance(self, tolerance: f64) -> BezPath {
-                    (&self).into_bezpath_with_tolerance(tolerance)
-                }
-            }
-        };
-    }
-
-    geo_object_into_bezpath!(geo::Point<f64>);
-    geo_object_into_bezpath!(geo::Line<f64>);
-    geo_object_into_bezpath!(geo::LineString<f64>);
-    geo_object_into_bezpath!(geo::Polygon<f64>);
-    geo_object_into_bezpath!(geo::MultiPoint<f64>);
-    geo_object_into_bezpath!(geo::MultiLineString<f64>);
-    geo_object_into_bezpath!(geo::MultiPolygon<f64>);
-    geo_object_into_bezpath!(geo::Rect<f64>);
-    geo_object_into_bezpath!(geo::Triangle<f64>);
-    geo_object_into_bezpath!(geo::Geometry<f64>);
-    geo_object_into_bezpath!(geo::GeometryCollection<f64>);
 
     pub(super) fn linestring_to_path_el(
         ls: &geo::LineString<f64>,

--- a/crates/vsvg/src/path/mod.rs
+++ b/crates/vsvg/src/path/mod.rs
@@ -10,7 +10,7 @@ use crate::{SvgPathWriter, Transforms};
 pub use flattened_path::{
     FlattenedPath, Polyline, multi_polygon_to_flattened_paths, polygon_to_flattened_paths,
 };
-pub use into_bezpath::{IntoBezPath, IntoBezPathTolerance};
+pub use into_bezpath::{IntoBezPath, IntoBezPathTolerance, IntoBezPaths, IntoBezPathsTolerance};
 pub use metadata::{PathMetadata, ResolvedPathMetadata};
 pub use path::Path;
 pub use point::Point;


### PR DESCRIPTION
## Summary

Introduces the `IntoBezPathsTolerance` / `IntoBezPaths` traits and dedicated implementations for multi-geometry types, laying the groundwork for correct multi-polygon hatching in #188.

### Problem

When a `geo::MultiPolygon` (e.g. from boolean operations) is converted to a single `BezPath`, all rings are flattened together and structural boundaries between polygons are lost. The hatching code then uses the heuristic "first subpath = exterior, rest = holes", which misinterprets the second polygon's exterior as a hole in the first.

### Solution

This PR adds the new trait infrastructure. The next PR (#188) wires it into `Draw::add_path`.

- **New traits**: `IntoBezPathsTolerance` and `IntoBezPaths` (plural), which return `Vec<BezPath>` — one per structural unit.
- **Blanket impl**: Any type implementing `IntoBezPathTolerance` (singular) automatically gets `IntoBezPathsTolerance` returning a one-element `Vec`, so all existing single-geometry types (kurbo shapes, `geo::Polygon`, etc.) work unchanged.
- **Dedicated impls** for multi-geometry types (`MultiPolygon`, `MultiLineString`, `MultiPoint`, `GeometryCollection`, `Geometry`) that return one `BezPath` per constituent, preserving structural boundaries. The old `IntoBezPathTolerance` impls for these types are removed (they now get it via the blanket from their dedicated `IntoBezPathsTolerance` impl).
- **Tests** verifying that `MultiPolygon` yields multiple bezpaths and single types yield one.

### Files changed

| File | Change |
|------|--------|
| `crates/vsvg/src/path/into_bezpath.rs` | New traits, blanket impls, dedicated multi-geo `IntoBezPathsTolerance` impls (replacing old `IntoBezPathTolerance` impls), tests |
| `crates/vsvg/src/path/mod.rs` | Export new traits |

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #188 
- <kbd>&nbsp;5&nbsp;</kbd> #191 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #187 
- <kbd>&nbsp;3&nbsp;</kbd> #186 
- <kbd>&nbsp;2&nbsp;</kbd> #184 
- <kbd>&nbsp;1&nbsp;</kbd> #183 
<!-- GitButler Footer Boundary Bottom -->